### PR TITLE
fix: Use leaf in `active-leaf-change` instead of `getLeaf()`

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -26,10 +26,10 @@ export default class MathLinks extends Plugin {
             })
         });
 
-        this.app.workspace.on("layout-change", () => {
-            let viewState = this.app.workspace.getLeaf().getViewState().state;
+        this.app.workspace.on("active-leaf-change", (leaf: WorkspaceLeaf) => {
+            let viewState = leaf.getViewState().state;
             if (viewState.mode == "source" && viewState.source == false) {
-                let livePreview = buildLivePreview(this, this.app);
+                let livePreview = buildLivePreview(this, this.app, leaf);
                 this.registerEditorExtension(livePreview);
             }
         });

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -4,7 +4,7 @@ import { RangeSetBuilder } from '@codemirror/state';
 import { Decoration, DecorationSet, ViewUpdate, PluginValue, EditorView, ViewPlugin, WidgetType } from '@codemirror/view';
 import { getMathLink, replaceWithMathLink } from './tools'
 
-export function buildLivePreview(plugin: Plugin, app: App)
+export function buildLivePreview(plugin: Plugin, app: App, leaf: WorkspaceLeaf)
 {
     class MathWidget extends WidgetType {
         outLinkFileName: string;
@@ -42,7 +42,7 @@ export function buildLivePreview(plugin: Plugin, app: App)
             }
 
             update(update: ViewUpdate) {
-                let viewState = app.workspace.getLeaf().getViewState().state;
+                let viewState = leaf.getViewState().state;
                 if (viewState.mode == "source" && viewState.source == false) {
                     this.decorations = this.buildDecorations(update.view);
                 } else {

--- a/test_vault/.obsidian/core-plugins-migration.json
+++ b/test_vault/.obsidian/core-plugins-migration.json
@@ -17,7 +17,7 @@
   "bookmarks": true,
   "markdown-importer": false,
   "zk-prefixer": false,
-  "random-note": false,
+  "random-note": true,
   "outline": true,
   "word-count": true,
   "slides": false,

--- a/test_vault/.obsidian/core-plugins.json
+++ b/test_vault/.obsidian/core-plugins.json
@@ -14,6 +14,7 @@
   "command-palette",
   "editor-status",
   "bookmarks",
+  "random-note",
   "outline",
   "word-count",
   "file-recovery"


### PR DESCRIPTION
Uses `active-leaf-change` instead of `layout-change` to obtain access to the current leaf, instead of using `getLeaf()`.