### PR TITLE
Bugfix in the code for block & heading mathLinks

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1,4 +1,5 @@
 import { TFile, renderMath, finishRenderMath, parseLinktext, resolveSubpath, getLinkpath } from "obsidian";
+import MathLinks from "./main";
 
 // Generate all mathLinks in element to be added in the MarkdownPostProcessor in reading view
 export function generateMathLinks(plugin: MathLinks, element: HTMLElement, sourcePath: string): void {
@@ -93,15 +94,18 @@ export function getMathLink(plugin: MathLinks, targetLink: string, sourcePath: s
             let subMathLink = "";
             if (subpathResult.type == "heading") {
                 subMathLink = subpathResult.current.heading;
-            } else if (subpathResult.type == "block" && cache.frontmatter["mathLink-blocks"]) {
+            } else if (subpathResult.type == "block" && cache.frontmatter["mathLink-blocks"] && cache.frontmatter["mathLink-blocks"][subpathResult.block.id]) {
                 subMathLink = "^" + cache.frontmatter["mathLink-blocks"][subpathResult.block.id];
             }
-
-            if (path) { 
-                mathLink = (cache.frontmatter.mathLink ?? path) + " > " + subMathLink;
-            } else { 
-                mathLink = subMathLink;
-            }            
+            if (subMathLink) { // cache.frontmatter["mathLink-blocks"][subpathResult.block.id] can be undefined, in which case subMathLink == ""
+                if (path) { 
+                    mathLink = (cache.frontmatter.mathLink ?? path) + " > " + subMathLink;
+                } else { 
+                    mathLink = subMathLink;
+                }    
+            } else {
+                mathLink = ""
+            }
         } else {
             mathLink = cache.frontmatter.mathLink;
             if (mathLink == "auto") {


### PR DESCRIPTION
Hi again @zhaoshenzhai . 
I'm sorry, I found a bug in the code that I wrote [the other day](https://github.com/zhaoshenzhai/obsidian-mathlinks/pull/27#issue-1826267179) in `src/tools.ts`. 
When you insert a link to a block but it doesn't have `mathLink-blocks` metadata, the link will be displayed as `^undefined` (see the example below).

I've fixed this, so could you review this PR?

(This PR is identical to #29, which is closed by my mistake.)

### source mode

<img width="422" alt="image" src="https://github.com/zhaoshenzhai/obsidian-mathlinks/assets/72342591/d5c118a7-d384-4d3d-92fd-38de3bfdb28d">


### old (commit 324d868)

<img width="422" alt="image" src="https://github.com/zhaoshenzhai/obsidian-mathlinks/assets/72342591/d378146a-1501-44d6-a579-0804919b5806">

### new (commit dcf7245)

<img width="422" alt="image" src="https://github.com/zhaoshenzhai/obsidian-mathlinks/assets/72342591/6fc64385-748d-4f98-866b-1a0049f35b77">
