### PR TITLE
API for integration with other plugins

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -9,7 +9,7 @@ export class MathLinksAPIAccount {
         this.metadataSet = {};
     }
 
-    update(path: string, newMetadata: MathLinksMetadata) {
+    update(path: string, newMetadata: MathLinksMetadata): void {
         let file = this.plugin.app.vault.getAbstractFileByPath(path);
         if (file instanceof TFile && file.extension == "md") {
             this.metadataSet[path] = Object.assign(
@@ -22,7 +22,7 @@ export class MathLinksAPIAccount {
         }
     }
 
-    get(path: string, blockID?: string) {
+    get(path: string, blockID?: string): string | undefined {
         // If blockID === undefined, return mathLink
         // If blockID is given, return the corresponding item of mathLink-blocks
         let metadata = this.metadataSet[path];
@@ -37,7 +37,7 @@ export class MathLinksAPIAccount {
         }
     }
 
-    delete(path: string, which?: string) {
+    delete(path: string, which?: string): void {
         // `which === undefined`: remove all the mathLinks associated with `path`
         // `which == "mathLink": remove `mathLink`
         // `which == "mathLink-blocks": remove `mathLink-blocks`
@@ -65,7 +65,7 @@ export class MathLinksAPIAccount {
         }
     }
 
-    deleteUser() {
+    deleteAccount(): void {
         let index = this.plugin.apiAccounts.findIndex(
             (account) => account.pluginID == this.pluginID
         );

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,11 +1,11 @@
-import { TFile } from 'obsidian';
+import { PluginManifest, TFile } from 'obsidian';
 
 import MathLinks, { MathLinksMetadata, MathLinksMetadataSet } from './main';
 
 export class MathLinksAPIAccount {
     metadataSet: MathLinksMetadataSet;
 
-    constructor(public plugin: MathLinks, public pluginID: string, public blockPrefix: string) {
+    constructor(public plugin: MathLinks, public manifest: PluginManifest, public blockPrefix: string) {
         this.metadataSet = {};
     }
 
@@ -67,7 +67,7 @@ export class MathLinksAPIAccount {
 
     deleteAccount(): void {
         let index = this.plugin.apiAccounts.findIndex(
-            (account) => account.pluginID == this.pluginID
+            (account) => account.manifest.id == this.manifest.id
         );
         this.plugin.apiAccounts.splice(index, 1);
     }

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,0 +1,56 @@
+import { App, TFile } from 'obsidian';
+
+import MathLinks, { MathLinksMetadata } from './main';
+
+export class MathLinksAPI {
+    constructor(public plugin: MathLinks) { }
+
+    checkIfEnabled() {
+        if (!this.plugin.settings.enableAPI) {
+            throw Error("MathLinks: MathLinks API is disabled");
+        }
+    }
+
+    update(path: string, newMetadata: MathLinksMetadata) {
+        this.checkIfEnabled();
+        let file = this.plugin.app.vault.getAbstractFileByPath(path);
+        if (file instanceof TFile && file.extension == "md") {
+            this.plugin.externalMathLinks[path] = Object.assign(
+                {}, 
+                this.plugin.externalMathLinks[path],
+                newMetadata
+            );    
+        } else {
+            throw Error(`MathLinks API: Invalid path: ${path}`);
+        }
+    }
+
+    delete(path: string, which?: string) {
+        // `which === undefined`: remove all the external mathLinks associated with `path`
+        // `which == "mathLink": remove `mathLink`
+        // `which == "mathLink-blocks": remove `mathLink-blocks`
+        // `which == <blockID>`: remove `mathLink-blocks[<blockID>]`
+        this.checkIfEnabled();
+        let metadata = this.plugin.externalMathLinks[path]
+        if (metadata) {
+            if (which === undefined) {
+                delete this.plugin.externalMathLinks[path];
+            } else if (which == "mathLink" || which == "mathLink-blocks") {
+                if (metadata[which] !== undefined) {
+                    delete metadata[which];
+                } else {
+                    throw Error(`MathLinks API: Key "${which}" does not exist in MathLinks.externalMathLinks[${path}]`);
+                }
+            } else {
+                let blocks = metadata["mathLink-blocks"];
+                if (blocks && blocks[which] !== undefined) {
+                    delete blocks[which];
+                } else {
+                    throw Error(`MathLinks API: Block ID "${which}" does not exist in MathLinks.externalMathLinks[${path}]["mathLink-blocks"]`);
+                }
+            }
+        } else {
+            throw Error(`MathLinks API: Path ${path} does not exist in MathLinks.externalMathLinks`);
+        }
+    }
+}

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,6 +1,13 @@
 import { PluginManifest, TFile } from 'obsidian';
 
-import MathLinks, { MathLinksMetadata, MathLinksMetadataSet } from './main';
+import MathLinks from './main';
+
+export interface MathLinksMetadata {
+    "mathLink"?: string;
+    "mathLink-blocks"?: Record<string, string>
+}
+
+export type MathLinksMetadataSet = Record<string, MathLinksMetadata>; // {[path]: [metadata for the file], ...}
 
 export class MathLinksAPIAccount {
     metadataSet: MathLinksMetadataSet;

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,16 +1,12 @@
-import { App, TFile } from 'obsidian';
+import { TFile } from 'obsidian';
 
 import MathLinks, { MathLinksMetadata, MathLinksMetadataSet } from './main';
 
-export class MathLinksAPI {
+export class MathLinksAPIAccount {
     metadataSet: MathLinksMetadataSet;
 
-    constructor(public plugin: MathLinks, public userID: string, public blockPrefix: string) {
-        if (this.plugin.mathLinksFromAPI[userID] !== undefined) {
-            throw Error(`MathLinks API: user ID ${userID} is already taken`);
-        }
-        this.plugin.mathLinksFromAPI[userID] = {};
-        this.metadataSet = this.plugin.mathLinksFromAPI[userID];
+    constructor(public plugin: MathLinks, public pluginID: string, public blockPrefix: string) {
+        this.metadataSet = {};
     }
 
     update(path: string, newMetadata: MathLinksMetadata) {
@@ -70,6 +66,9 @@ export class MathLinksAPI {
     }
 
     deleteUser() {
-        delete this.plugin.mathLinksFromAPI[this.userID];
+        let index = this.plugin.apiAccounts.findIndex(
+            (account) => account.pluginID == this.pluginID
+        );
+        this.plugin.apiAccounts.splice(index, 1);
     }
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,5 +1,4 @@
 import { PluginManifest, TFile } from 'obsidian';
-
 import MathLinks from './main';
 
 export interface MathLinksMetadata {

--- a/src/main.ts
+++ b/src/main.ts
@@ -55,18 +55,18 @@ export default class MathLinks extends Plugin {
         await this.saveData(this.settings);
     }
 
-    getAPIAccount(plugin: Plugin, blockPrefix: string = "^") {
-        // register `plugin` as a user of MathLinks API and return the account
-        let pluginID = plugin.manifest.id;
+    getAPIAccount(userPlugin: Plugin, blockPrefix: string = "^") {
+        // register `userPlugin` as a user of MathLinks API and return the account
+
         // If the account already exists, return it
         let account = this.apiAccounts.find(
-            (account) => account.pluginID == pluginID
+            (account) => account.manifest.id == userPlugin.manifest.id
         );
         if (account) {
             return account;  
         }
         // If not, create a new one
-        account = new MathLinksAPIAccount(this, pluginID, blockPrefix);
+        account = new MathLinksAPIAccount(this, userPlugin.manifest, blockPrefix);
         this.apiAccounts.push(account);
         return account;
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,10 +9,12 @@ export interface MathLinksMetadata {
     "mathLink-blocks"?: Record<string, string>
 }
 
+export type MathLinksMetadataSet = Record<string, MathLinksMetadata>; // {[path]: [metadata for the file], ...}
+
 export default class MathLinks extends Plugin {
     settings: MathLinksSettings;
-    externalMathLinks: Record<string, MathLinksMetadata> = {};
-    api: MathLinksAPI;
+    mathLinksFromAPI: Record<string, MathLinksMetadataSet>; // {[userID]: [metadata set for the user], ...}
+    APIUserPrecedence: {userID: string, blockPrefix: string}[];
 
     async onload() {
         await this.loadSettings();
@@ -42,7 +44,8 @@ export default class MathLinks extends Plugin {
             }
         });
 
-        this.api = new MathLinksAPI(this);
+        this.mathLinksFromAPI = {};
+        this.APIUserPrecedence = [];
     }
 
     async loadSettings() {
@@ -52,5 +55,11 @@ export default class MathLinks extends Plugin {
 
     async saveSettings() {
         await this.saveData(this.settings);
+    }
+
+    getAPI(userID: string, blockPrefix: string = "^") {
+        this.APIUserPrecedence.push({userID, blockPrefix});
+        let api = new MathLinksAPI(this, userID, blockPrefix);
+        return api;
     }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,8 +2,18 @@ import { App, Plugin, TFile, loadMathJax } from "obsidian";
 import { generateMathLinks, isValid } from "./tools";
 import { MathLinksSettings, MathLinksSettingTab, DEFAULT_SETTINGS } from "./settings";
 import { buildLivePreview } from "./preview";
+import { MathLinksAPI } from "./api";
+
+export interface MathLinksMetadata {
+    "mathLink"?: string;
+    "mathLink-blocks"?: Record<string, string>
+}
 
 export default class MathLinks extends Plugin {
+    settings: MathLinksSettings;
+    externalMathLinks: Record<string, MathLinksMetadata> = {};
+    api: MathLinksAPI;
+
     async onload() {
         await this.loadSettings();
         await loadMathJax();
@@ -31,6 +41,8 @@ export default class MathLinks extends Plugin {
                 });
             }
         });
+
+        this.api = new MathLinksAPI(this);
     }
 
     async loadSettings() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -55,7 +55,7 @@ export default class MathLinks extends Plugin {
         await this.saveData(this.settings);
     }
 
-    getAPI(plugin: Plugin, blockPrefix: string = "^") {
+    getAPIAccount(plugin: Plugin, blockPrefix: string = "^") {
         // register `plugin` as a user of MathLinks API and return the account
         let pluginID = plugin.manifest.id;
         // If the account already exists, return it

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,9 @@
 import { App, Plugin, TFile, loadMathJax } from "obsidian";
-import { generateMathLinks, isValid } from "./tools";
 import { MathLinksSettings, MathLinksSettingTab, DEFAULT_SETTINGS } from "./settings";
-import { buildLivePreview } from "./preview";
 import { MathLinksAPIAccount } from "./api";
+import { generateMathLinks } from "./links";
+import { buildLivePreview } from "./preview";
+import { isValid } from "./utils"
 
 export default class MathLinks extends Plugin {
     settings: MathLinksSettings;
@@ -49,13 +50,9 @@ export default class MathLinks extends Plugin {
     }
 
     getAPIAccount(userPlugin: Plugin, blockPrefix: string = "^") {
-        // register `userPlugin` as a user of MathLinks API and return the account
-
-        // If the account already exists, return it
         let account = this.apiAccounts.find((account) => account.manifest.id == userPlugin.manifest.id);
         if (account) return account;
 
-        // If not, create a new one
         account = new MathLinksAPIAccount(this, userPlugin.manifest, blockPrefix);
         this.apiAccounts.push(account);
         return account;

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,6 @@ import { MathLinksSettings, MathLinksSettingTab, DEFAULT_SETTINGS } from "./sett
 import { buildLivePreview } from "./preview";
 import { MathLinksAPIAccount } from "./api";
 
-
 export default class MathLinks extends Plugin {
     settings: MathLinksSettings;
     apiAccounts: MathLinksAPIAccount[];
@@ -53,12 +52,9 @@ export default class MathLinks extends Plugin {
         // register `userPlugin` as a user of MathLinks API and return the account
 
         // If the account already exists, return it
-        let account = this.apiAccounts.find(
-            (account) => account.manifest.id == userPlugin.manifest.id
-        );
-        if (account) {
-            return account;  
-        }
+        let account = this.apiAccounts.find((account) => account.manifest.id == userPlugin.manifest.id);
+        if (account) return account;
+
         // If not, create a new one
         account = new MathLinksAPIAccount(this, userPlugin.manifest, blockPrefix);
         this.apiAccounts.push(account);

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,12 +4,6 @@ import { MathLinksSettings, MathLinksSettingTab, DEFAULT_SETTINGS } from "./sett
 import { buildLivePreview } from "./preview";
 import { MathLinksAPIAccount } from "./api";
 
-export interface MathLinksMetadata {
-    "mathLink"?: string;
-    "mathLink-blocks"?: Record<string, string>
-}
-
-export type MathLinksMetadataSet = Record<string, MathLinksMetadata>; // {[path]: [metadata for the file], ...}
 
 export default class MathLinks extends Plugin {
     settings: MathLinksSettings;

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -2,6 +2,7 @@ import { syntaxTree } from "@codemirror/language";
 import { RangeSetBuilder } from "@codemirror/state";
 import { Decoration, DecorationSet, ViewUpdate, EditorView, ViewPlugin, WidgetType } from "@codemirror/view";
 import { getMathLink, addMathLink, getSuperCharged } from "./tools"
+import MathLinks from "./main";
 
 export function buildLivePreview(plugin: MathLinks, leaf: WorkspaceLeaf): Promise<ViewPlugin>
 {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -25,16 +25,16 @@ export class MathLinksSettingTab extends PluginSettingTab {
         const { containerEl } = this;
 
         containerEl.empty();
-        containerEl.createEl("h2", { text: "MathLinks Settings" });
+        containerEl.createEl("h2", {text: "MathLinks Settings"});
 
         // Add a new template
         new Setting(containerEl)
             .setName("Add a new template")
             .setDesc(
                 createFragment((e) => {
-                    e.createSpan({ text: "Generate mathLinks with a new template. Use " });
-                    e.createEl("code", { text: "mathLink: auto" });
-                    e.createSpan({ text: " to use templates in a file." });
+                    e.createSpan({text: "Generate mathLinks with a new template. Use "});
+                    e.createEl("code", {text: "mathLink: auto"});
+                    e.createSpan({text: " to use templates in a file."});
                 })
             )
             .addButton((button: ButtonComponent): ButtonComponent => {
@@ -193,7 +193,7 @@ export class MathLinksSettingTab extends PluginSettingTab {
                         excludedFilePath = null;
                 });
             })
-            .addExtraButton((button: ButtonComponent): ButtonComponent => {
+            .addExtraButton((button: ExtraButtonComponent): ExtraButtonComponent => {
                 let b = button
                     .setTooltip("Remove")
                     .setIcon("trash")
@@ -229,11 +229,11 @@ export class MathLinksSettingTab extends PluginSettingTab {
             .setDesc(
                 createFragment((e) => {
                     let accounts = this.plugin.apiAccounts;
-                    e.createSpan({ text: "Allow other community plugins to use MathLinks." });
+                    e.createSpan({text: "Allow other community plugins to use MathLinks."});
                     if (accounts.length) {
                         let list = e.createEl("ul");
                         for (let account of accounts) {
-                            list.createEl("li", { text: account.manifest.name });
+                            list.createEl("li", {text: account.manifest.name});
                         }    
                     }
                 })
@@ -326,11 +326,11 @@ class AddExcludedModal extends Modal {
             .setName("File name/path of folder")
             .setDesc(
                 createFragment((e) => {
-                    e.createSpan({ text: "Enter a file as" });
-                    e.createEl("code", { text: "path/name.md" });
-                    e.createSpan({ text: " and a folder as " });
-                    e.createEl("code", { text: "path" });
-                    e.createSpan({ text: "." });
+                    e.createSpan({text: "Enter a file as"});
+                    e.createEl("code", {text: "path/name.md"});
+                    e.createSpan({text: " and a folder as "});
+                    e.createEl("code", {text: "path"});
+                    e.createSpan({text: "."});
                 })
             )
             .addText((text) => {
@@ -383,7 +383,7 @@ class ConfirmModal extends Modal {
         const { contentEl } = this;
         contentEl.empty();
 
-        contentEl.createEl("h3", { text: this.areYouSure });
+        contentEl.createEl("h3", {text: this.areYouSure});
         loadButtonsToClose(this, this.contentEl.createDiv(), this.proceed, this.noProceed);
     }
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -25,16 +25,16 @@ export class MathLinksSettingTab extends PluginSettingTab {
         const { containerEl } = this;
 
         containerEl.empty();
-        containerEl.createEl("h2", {text: "MathLinks Settings"});
+        containerEl.createEl("h2", { text: "MathLinks Settings" });
 
         // Add a new template
         new Setting(containerEl)
             .setName("Add a new template")
             .setDesc(
                 createFragment((e) => {
-                    e.createSpan({text: "Generate mathLinks with a new template. Use "});
-                    e.createEl("code", {text: "mathLink: auto"});
-                    e.createSpan({text: " to use templates in a file."});
+                    e.createSpan({ text: "Generate mathLinks with a new template. Use " });
+                    e.createEl("code", { text: "mathLink: auto" });
+                    e.createSpan({ text: " to use templates in a file." });
                 })
             )
             .addButton((button: ButtonComponent): ButtonComponent => {
@@ -226,8 +226,18 @@ export class MathLinksSettingTab extends PluginSettingTab {
         // Enable API
         new Setting(containerEl)
             .setName("Enable MathLinks API")
-            .setDesc("Allow other community plugins to use MathLinks.")
-            .addToggle((toggle: ToggleComponent) => {
+            .setDesc(
+                createFragment((e) => {
+                    let accounts = this.plugin.apiAccounts;
+                    e.createSpan({ text: "Allow other community plugins to use MathLinks." });
+                    if (accounts.length) {
+                        let list = e.createEl("ul");
+                        for (let account of accounts) {
+                            list.createEl("li", { text: account.manifest.name });
+                        }    
+                    }
+                })
+            ).addToggle((toggle: ToggleComponent) => {
                 toggle.setValue(this.plugin.settings.enableAPI)
                     .onChange(async (value: boolean) => {
                         this.plugin.settings.enableAPI = value;
@@ -316,11 +326,11 @@ class AddExcludedModal extends Modal {
             .setName("File name/path of folder")
             .setDesc(
                 createFragment((e) => {
-                    e.createSpan({text: "Enter a file as"});
-                    e.createEl("code", {text: "path/name.md"});
-                    e.createSpan({text: " and a folder as "});
-                    e.createEl("code", {text: "path"});
-                    e.createSpan({text: "."});
+                    e.createSpan({ text: "Enter a file as" });
+                    e.createEl("code", { text: "path/name.md" });
+                    e.createSpan({ text: " and a folder as " });
+                    e.createEl("code", { text: "path" });
+                    e.createSpan({ text: "." });
                 })
             )
             .addText((text) => {
@@ -373,7 +383,7 @@ class ConfirmModal extends Modal {
         const { contentEl } = this;
         contentEl.empty();
 
-        contentEl.createEl("h3", {text: this.areYouSure});
+        contentEl.createEl("h3", { text: this.areYouSure });
         loadButtonsToClose(this, this.contentEl.createDiv(), this.proceed, this.noProceed);
     }
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,13 +1,16 @@
-import { Setting, PluginSettingTab, Modal, TextComponent, DropdownComponent, Notice, TFile } from "obsidian";
+import { Setting, PluginSettingTab, Modal, TextComponent, DropdownComponent, Notice, TFile, ToggleComponent, ButtonComponent, ExtraButtonComponent } from "obsidian";
+import MathLinks from "./main";
 
 export interface MathLinksSettings {
     templates: string[];
     excludedFilePaths: string[];
+    enableAPI: boolean;
 }
 
 export const DEFAULT_SETTINGS: MathLinksSettings = {
     templates: [],
     excludedFilePaths: [],
+    enableAPI: true,
 }
 
 export class MathLinksSettingTab extends PluginSettingTab {
@@ -18,7 +21,7 @@ export class MathLinksSettingTab extends PluginSettingTab {
         this.plugin = plugin;
     }
 
-    async display(): void {
+    async display(): Promise<void> {
         const { containerEl } = this;
 
         containerEl.empty();
@@ -82,7 +85,7 @@ export class MathLinksSettingTab extends PluginSettingTab {
                         templateTitle = null;
                 });
             })
-            .addExtraButton((button: ButtonComponent): ButtonComponent => {
+            .addExtraButton((button: ExtraButtonComponent): ExtraButtonComponent => {
                 let b = button
                     .setTooltip("Edit")
                     .setIcon("edit")
@@ -109,7 +112,7 @@ export class MathLinksSettingTab extends PluginSettingTab {
                     });
                 return b;
             })
-            .addExtraButton((button: ButtonComponent): ButtonComponent => {
+            .addExtraButton((button: ExtraButtonComponent): ExtraButtonComponent => {
                 let b = button
                     .setTooltip("Delete")
                     .setIcon("trash")
@@ -219,6 +222,18 @@ export class MathLinksSettingTab extends PluginSettingTab {
                     });
                 return b;
             });
+
+        // 
+        new Setting(containerEl)
+            .setName("Enable MathLinks API")
+            .setDesc("Allow other community plugins to use MathLinks.")
+            .addToggle((toggle: ToggleComponent) => {
+                toggle.setValue(this.plugin.settings.enableAPI)
+                    .onChange(async (value: boolean) => {
+                        this.plugin.settings.enableAPI = value;
+                        await this.plugin.saveSettings();
+                    })
+            })
     }
 }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,4 +1,4 @@
-import { Setting, PluginSettingTab, Modal, TextComponent, DropdownComponent, Notice, TFile, ToggleComponent, ButtonComponent, ExtraButtonComponent } from "obsidian";
+import { Setting, PluginSettingTab, Modal, TextComponent, DropdownComponent, Notice, TFile, ToggleComponent, ButtonComponent, ExtraButtonComponent, App } from "obsidian";
 import MathLinks from "./main";
 
 export interface MathLinksSettings {
@@ -223,7 +223,7 @@ export class MathLinksSettingTab extends PluginSettingTab {
                 return b;
             });
 
-        // 
+        // Enable API
         new Setting(containerEl)
             .setName("Enable MathLinks API")
             .setDesc("Allow other community plugins to use MathLinks.")
@@ -233,7 +233,7 @@ export class MathLinksSettingTab extends PluginSettingTab {
                         this.plugin.settings.enableAPI = value;
                         await this.plugin.saveSettings();
                     })
-            })
+            });
     }
 }
 

--- a/src/supercharged.ts
+++ b/src/supercharged.ts
@@ -1,0 +1,43 @@
+import MathLinks from "./main";
+
+export function addSuperCharged(plugin: MathLinks, span: HTMLElement, outLinkFile: TFile): void {
+    if (outLinkFile && plugin.app.plugins.enabledPlugins.has("supercharged-links-obsidian")) {
+        let superCharged = getSuperCharged(plugin, outLinkFile);
+        span.classList.add("data-link-icon");
+        span.classList.add("data-link-icon-after");
+        span.classList.add("data-link-text");
+        span.setAttribute("data-link-path", outLinkFile.path);
+        span.setAttribute("data-link-tags", superCharged[0]);
+        for (let i = 0; i < superCharged[1].length; i++)
+            span.setAttribute("data-link-" + superCharged[1][i][0], superCharged[1][i][1]);
+    }
+}
+
+function getSuperCharged(plugin: MathLinks, file: TFile): [string, [string, string][]] {
+    const data = app.plugins.getPlugin("supercharged-links-obsidian").settings;
+
+    let tagArr = plugin.app.metadataCache.getFileCache(file).tags;
+    let tags: string = "";
+    if (tagArr) {
+        for (let i = 0; i < tagArr.length; i++)
+            tags += tagArr[i].tag.replace(/#/, "") + " ";
+        tags = tags.trimEnd();
+    }
+
+    let attributes: [string, string][] = [];
+    let frontmatter = plugin.app.metadataCache.getFileCache(file).frontmatter;
+    for (let attr in frontmatter) {
+        if (attr != "mathLink" && attr != "position") {
+            let selectors = data.selectors;
+            for (let i = 0; i < selectors.length; i++) {
+                if (selectors[i].name == attr && selectors[i].value == frontmatter[attr]) {
+                    attributes.push([attr, frontmatter[attr]]);
+                } else if (selectors[i].type == "tag" && selectors[i].value == frontmatter[attr] && data.targetTags) {
+                    attributes.push([attr, frontmatter[attr]]);
+                }
+            }
+        }
+    }
+
+    return [tags, attributes];
+}

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -96,25 +96,7 @@ export function getMathLink(plugin: MathLinks, targetLink: string, sourcePath: s
         } else {
             mathLink = cache.frontmatter.mathLink;
             if (mathLink == "auto") {
-                let templates = plugin.settings.templates;
-                mathLink = file.name.replace("\.md", "");
-                for (let i = 0; i < templates.length; i++) {
-                    let replaced = new RegExp(templates[i].replaced);
-                    let replacement = templates[i].replacement;
-
-                    let flags = "";
-                    if (templates[i].globalMatch)
-                        flags += "g";
-                    if (!templates[i].sensitive)
-                        flags += "i";
-
-                    if (templates[i].word)
-                        replaced = RegExp(replaced.source.replace(/^/, "\\b").replace(/$/, "\\b"), flags);
-                    else
-                        replaced = RegExp(replaced.source, flags);
-
-                    mathLink = mathLink.replace(replaced, replacement);
-                }
+                mathLink = getMathLinkFromTemplates(plugin, file);
             }
         }
     }
@@ -160,6 +142,28 @@ function getMathLinkFromSubpath(
     } else {
         return "";
     }
+}
+
+function getMathLinkFromTemplates(plugin: MathLinks, file: TFile): string {
+    let templates = plugin.settings.templates;
+    mathLink = file.name.replace(/\.md$/, "");
+    for (let i = 0; i < templates.length; i++) {
+        let replaced = new RegExp(templates[i].replaced);
+        let replacement = templates[i].replacement;
+
+        let flags = "";
+        if (templates[i].globalMatch) flags += "g";
+        if (!templates[i].sensitive) flags += "i";
+
+        if (templates[i].word)
+            replaced = RegExp(replaced.source.replace(/^/, "\\b").replace(/$/, "\\b"), flags);
+        else
+            replaced = RegExp(replaced.source, flags);
+
+        mathLink = mathLink.replace(replaced, replacement);
+    }
+
+    return mathLink;
 }
 
 export function getSuperCharged(plugin: MathLinks, file: TFile): [string, [string, string][]] {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -93,7 +93,7 @@ export function getMathLink(plugin: MathLinks, targetLink: string, sourcePath: s
     if (cache.frontmatter) {
         if (subpathResult) {
             mathLink = getMathLinkFromSubpath(path, subpathResult, cache.frontmatter, "^");
-        } else {
+        } else if (path) {
             mathLink = cache.frontmatter.mathLink;
             if (mathLink == "auto") {
                 mathLink = getMathLinkFromTemplates(plugin, file);

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -121,12 +121,11 @@ export function getMathLink(plugin: MathLinks, targetLink: string, sourcePath: s
 
     // Read mathLink registered via API
     if (!mathLink && plugin.settings.enableAPI) {
-        for (let { userID, blockPrefix } of plugin.APIUserPrecedence) {
-            let metadataSet = plugin.mathLinksFromAPI[userID];
-            if (metadataSet && metadataSet[file.path]) {
-                let metadata = metadataSet[file.path];
+        for (let account of plugin.apiAccounts) {
+            if (account.metadataSet[file.path]) {
+                let metadata = account.metadataSet[file.path];
                 if (subpathResult) {
-                    mathLink = getMathLinkFromSubpath(path, subpathResult, metadata, blockPrefix);
+                    mathLink = getMathLinkFromSubpath(path, subpathResult, metadata, account.blockPrefix);
                 } else {
                     mathLink = metadata["mathLink"] ?? "";
                 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,37 @@
+import MathLinks from "./main";
+
+export function isValid(plugin: MathLinks, element: HTMLElement, fileName: string): boolean {
+    while (element.parentNode && element.parentNode.nodeName.toLowerCase() != "body") {
+        element = element.parentNode;
+        if (element.className.toLowerCase().includes("canvas")) {
+            return true;
+        }
+    }
+
+    for (let i = 0; i < plugin.settings.excludedFilePaths.length; i++) {
+        let path = plugin.settings.excludedFilePaths[i];
+        if (path.isFile && fileName == path.path) {
+            return false;
+        } else if (!path.isFile) {
+            let pathRegex = new RegExp(`\\b${path.path}/`);
+            if (pathRegex.test(fileName)) return false;
+        }
+    }
+
+    return true;
+}  
+
+// Convert "filename#heading" to "filename > heading" and "filename#^blockID" to "filename > ^blockID"
+export function translateLink(targetLink: string): string {
+    function translateLinkImpl(targetLink: string, pattern: RegExp): string | undefined {
+        let result = pattern.exec(targetLink);
+        if (result)
+            return (result[1] ? `${result[1]} > ` : "") + `${result[2]}`
+    }
+
+    let headingPattern = /(^.*)#([^\^].*)/;
+    let blockPattern = /(^.*)#(\^[a-zA-Z0-9\-]+)/;
+    let translatedAsHeading = translateLinkImpl(targetLink, headingPattern);
+    let translatedAsBlock = translateLinkImpl(targetLink, blockPattern);
+    return translatedAsHeading ?? translatedAsBlock ?? "";
+}

--- a/test_vault/.obsidian/app.json
+++ b/test_vault/.obsidian/app.json
@@ -1,7 +1,7 @@
 {
   "vimMode": true,
   "promptDelete": false,
-  "useMarkdownLinks": true,
+  "useMarkdownLinks": false,
   "alwaysUpdateLinks": true,
   "newFileLocation": "folder",
   "newFileFolderPath": "Tests"

--- a/test_vault/.obsidian/community-plugins.json
+++ b/test_vault/.obsidian/community-plugins.json
@@ -1,7 +1,7 @@
 [
   "dataview",
-  "supercharged-links-obsidian",
   "obsidian-style-settings",
   "mathlinks",
-  "obsidian-math-booster"
+  "obsidian-math-booster",
+  "supercharged-links-obsidian"
 ]

--- a/test_vault/.obsidian/community-plugins.json
+++ b/test_vault/.obsidian/community-plugins.json
@@ -2,5 +2,6 @@
   "dataview",
   "supercharged-links-obsidian",
   "obsidian-style-settings",
-  "mathlinks"
+  "mathlinks",
+  "obsidian-math-booster"
 ]

--- a/test_vault/.obsidian/plugins/mathlinks/data.json
+++ b/test_vault/.obsidian/plugins/mathlinks/data.json
@@ -1,0 +1,14 @@
+{
+  "templates": [
+    {
+      "title": "Templates",
+      "replaced": "Templates",
+      "replacement": "$\\Leftrightarrow$",
+      "globalMatch": true,
+      "sensitive": true,
+      "word": true
+    }
+  ],
+  "excludedFilePaths": [],
+  "enableAPI": true
+}

--- a/test_vault/.obsidian/plugins/obsidian-math-booster/data.json
+++ b/test_vault/.obsidian/plugins/obsidian-math-booster/data.json
@@ -1,0 +1,18 @@
+{
+  "settings": {
+    "/": {
+      "lang": "en",
+      "number_prefix": "",
+      "number_suffix": "",
+      "number_init": 1,
+      "number_style": "arabic",
+      "eq_number_style": "arabic",
+      "label_prefix": "",
+      "rename": {},
+      "preamblePath": "",
+      "lineByLine": true
+    },
+    "Tests/Callouts.md": {}
+  },
+  "excludedFiles": []
+}

--- a/test_vault/.obsidian/plugins/obsidian-math-booster/manifest.json
+++ b/test_vault/.obsidian/plugins/obsidian-math-booster/manifest.json
@@ -1,0 +1,11 @@
+{
+	"id": "obsidian-math-booster",
+	"name": "Obsidian Math Booster",
+	"version": "0.3.0",
+	"minAppVersion": "1.3.5",
+	"description": "Introduce LaTeX-like mathematic note taking features into Obsidian",
+	"author": "Ryota Ushio",
+	"authorUrl": "https://github.com/RyotaUshio",
+	"fundingUrl": "https://www.buymeacoffee.com/ryotaushio",
+	"isDesktopOnly": false
+}

--- a/test_vault/.obsidian/plugins/obsidian-style-settings/data.json
+++ b/test_vault/.obsidian/plugins/obsidian-style-settings/data.json
@@ -1,4 +1,3 @@
 {
-  "supercharged-links@@ebb6-7451-before": "TAG ",
-  "supercharged-links@@c-ebb6-7451-use-background": true
+  "supercharged-links@@ebb6-7451-before": "TAG "
 }

--- a/test_vault/.obsidian/plugins/supercharged-links-obsidian/data.json
+++ b/test_vault/.obsidian/plugins/supercharged-links-obsidian/data.json
@@ -18,9 +18,9 @@
       "match": "exact",
       "uid": "ebb6-7451",
       "selectText": true,
-      "selectAppend": false,
+      "selectAppend": true,
       "selectPrepend": true,
-      "selectBackground": true
+      "selectBackground": false
     }
   ]
 }

--- a/test_vault/Tests/Main.md
+++ b/test_vault/Tests/Main.md
@@ -6,3 +6,10 @@ tags: tagTest
 This note contains a `mathLink`. ^0283fa
 
 # Section
+$$\begin{equation}
+    e^{\pi i}=-1
+\end{equation}$$
+
+^63254e
+
+[[#^63254e]]

--- a/test_vault/Tests/Templates.md
+++ b/test_vault/Tests/Templates.md
@@ -1,0 +1,5 @@
+---
+mathLink: auto
+---
+
+[[Templates]]


### PR DESCRIPTION
Hi, thank you again for maintaining this awesome project.

Recently, I've been developing a new plugin for mathematical note taking.
In the development process, I realized that MathLinks is very powerful not only in rendering MathJax but also in dynamically updating link texts.
It would be great if other community plugins could utilize this power.

At first, I was directly editing the YAML frontmatter and adding `mathLink`/`mathLink-blocks` to do it. However, this is unsafe and degrades users' experience.

So, I would like to propose adding an API to MathLinks for integration with other plugins. 

I would truly appreciate it if you could approve this PR and include it in the next release, in which case my plugin will be able to provide really awesome experience to many Obsidian users who take mathematical notes. 
It will be beneficial for other plugin developers, too.

If you are interested in what can be done with this API, please check out the followings:

- repo: https://github.com/RyotaUshio/obsidian-math-booster
- docs (tentative): https://ryotaushio.github.io/obsidian-math-booster/

(Note that you have to clone the latest commit of the [add-api branch of my fork](https://github.com/RyotaUshio/obsidian-mathlinks/tree/add-api) and the [master branch of my plugin](https://github.com/RyotaUshio/obsidian-math-booster) if you want to try it.)

Let me explain the related codes that I've added. 

### [api.ts](https://github.com/RyotaUshio/obsidian-mathlinks/blob/add-api/src/api.ts)

```ts
export interface MathLinksMetadata {
    "mathLink"?: string;
    "mathLink-blocks"?: Record<string, string>
}

export type MathLinksMetadataSet = Record<string, MathLinksMetadata>; // {[path]: [metadata for the file], ...}

export class MathLinksAPIAccount {
    metadataSet: MathLinksMetadataSet;
    constructor(public plugin: MathLinks, public manifest: PluginManifest, public blockPrefix: string);
    update(path: string, newMetadata: MathLinksMetadata): void;
    get(path: string, blockID?: string): string | undefined;
    delete(path: string, which?: string): void;
    deleteAccount(): void;
}
```

- `MathLinksMetadata` is the same thing as `mathLink` and `mathLink-blocks` in the YAML frontmater.
- `MathLinksMetadataSet` is a dictionary whose key is a note path and the value is the corresponding `MathLinksMetadata` object.
- `MathLinksAPIAccount` is the interface through which another plugin can handle its `MathLinksMetadataSet` object. 
  - Each plugin that wants to use this API is given an account. 
  - Each account has access to its own `metadataSet` only. It cannot modify the user-defined `mathLink` field in the frontmatter, nor other user plugins' `metadataSet`.
  - It can update/delete `mathLinks`/`mathLink-blocks` metadata **in a programmatic manner without directly editing the YAML frontmatter**.

### [main.ts](https://github.com/RyotaUshio/obsidian-mathlinks/blob/add-api/src/main.ts)

```ts
export default class MathLinks extends Plugin {
    apiAccounts: MathLinksAPIAccount[];
    ...
    getAPIAccount(userPlugin: Plugin, blockPrefix: string = "^"): MathLinksAPIAccount;
}
```

If another plugin (`userPlugin`) wants to use the API, it calls the `getAPIAccount` method of `MathLinks`. It registers `userPlugin` as a user of MathLinks API and returns its account.
All the issued account are stored in `apiAccounts`.

### [tools.ts/getMathLink()](https://github.com/RyotaUshio/obsidian-mathlinks/blob/c6604379a63b4133b1b4854a423af8e47ae4552f/src/tools.ts#L122)

Importantly, the metadata registered by other plugins via the API is used, only if the frontmatter doesn't have `mathLink` (or `mathLink-blocks`).
Therefore, **adding the API will not cause any change if mathLinks already exist in the frontmatter**.
**User-defined (i.e. defined in the frontmatter) mathLinks always have the highest precedence.**

(As you can see in the code, the precedence among user plugins is determined by the order in which they are stored in `MathLinks.apiAccounts`. So it would be possible to allow users to change this precedence in the settings.)

### [settings.ts](https://github.com/RyotaUshio/obsidian-mathlinks/blob/c6604379a63b4133b1b4854a423af8e47ae4552f/src/settings.ts#L226)

In the MathLinks settings, users can choose whether to allow other plugins to use the API.

<img width="923" alt="image" src="https://github.com/zhaoshenzhai/obsidian-mathlinks/assets/72342591/03cc33be-fbd4-42a7-97af-efa7ab78da04">

Thank you!