### PR TITLE
[based on 0.4.1] Fix dynamic updates in reading mode & remove `targetDisplay` in `MathLinksRenderChild`

### DIFF
--- a/src/links.ts
+++ b/src/links.ts
@@ -163,10 +163,8 @@ export function getMathLink(plugin: MathLinks, targetLink: string, sourcePath: s
     if (!mathLink && plugin.settings.enableAPI) {
         for (let account of plugin.apiAccounts) {
             if (account.metadataSet[file.path]) {
-                console.log(`getMathLink: ${file.path}:`, account.metadataSet[file.path]);
                 let metadata = account.metadataSet[file.path];
                 if (subpathResult) {
-                    console.log("subpathResult");
                     mathLink = getMathLinkFromSubpath(plugin, path, subpathResult, metadata, account.blockPrefix, account.enableFileNameBlockLinks);
                 } else {
                     mathLink = metadata["mathLink"] ?? "";

--- a/src/links.ts
+++ b/src/links.ts
@@ -96,12 +96,12 @@ export async function renderTextWithMathAsync(source: string): Promise<(HTMLElem
         textFrom = mathPattern.lastIndex;
 
         let mathJaxEl = renderMath(mathString, false);
-        await finishRenderMath();
 
         let mathSpan = createSpan({ cls: ["math", "math-inline", "is-loaded"] });
         mathSpan.replaceChildren(mathJaxEl);
         elements.push(mathSpan);
     }
+    await finishRenderMath();
 
     if (textFrom < source.length) elements.push(source.slice(textFrom));
 
@@ -191,9 +191,9 @@ function getMathLinkFromSubpath(plugin: MathLinks, linkpath: string, subpathResu
     if (subMathLink) {
         if (linkpath && enableFileNameBlockLinks) {
             return (metadata["mathLink"] ?? linkpath) + " > " + subMathLink;
-        } else { 
+        } else {
             return subMathLink;
-        }    
+        }
     } else {
         return "";
     }

--- a/src/links.ts
+++ b/src/links.ts
@@ -44,18 +44,26 @@ export class MathLinksRenderChild extends MarkdownRenderChild {
 
     async update(): Promise<void> {
         let mathLink = "";
+        console.log(`update(): entered: ${this.displayText}`);
         if (this.displayText != this.targetLink && this.displayText != translateLink(this.targetLink)) {
             // [[note|display]] -> use display as mathLink
+            console.log("update(): use display");
             mathLink = this.displayText;
         } else {
             const targetName = this.targetFile?.basename;
             const targetDisplay = this.containerEl.innerText;
-            if (targetDisplay == targetName || targetDisplay == translateLink(this.targetLink)) {
+            console.log(`targetName = ${targetName}`);
+            console.log(`targetDisplay = ${targetDisplay}`);
+            console.log(`this.targetLink = ${this.targetLink}`);
+            console.log(`translateLink(this.targetLink) = ${translateLink(this.targetLink)}`);
+            if (this.displayText == targetName || this.displayText == translateLink(this.targetLink)) {
                 // [[note]], [[note#heading]] or [[note#^blockID]]
+                console.log("update(): go getMathLinks");
                 mathLink = getMathLink(this.plugin, this.targetLink, this.sourcePath);
             }
         }
 
+        console.log(`update: ${this.displayText}: mathLink = "${mathLink}"`);
         if (mathLink) {
             const children = await renderTextWithMathAsync(mathLink);
             this.containerEl.replaceChildren(...children);
@@ -164,8 +172,10 @@ export function getMathLink(plugin: MathLinks, targetLink: string, sourcePath: s
     if (!mathLink && plugin.settings.enableAPI) {
         for (let account of plugin.apiAccounts) {
             if (account.metadataSet[file.path]) {
+                console.log(`getMathLink: ${file.path}:`, account.metadataSet[file.path]);
                 let metadata = account.metadataSet[file.path];
                 if (subpathResult) {
+                    console.log("subpathResult");
                     mathLink = getMathLinkFromSubpath(plugin, path, subpathResult, metadata, account.blockPrefix, account.enableFileNameBlockLinks);
                 } else {
                     mathLink = metadata["mathLink"] ?? "";

--- a/src/links.ts
+++ b/src/links.ts
@@ -44,26 +44,17 @@ export class MathLinksRenderChild extends MarkdownRenderChild {
 
     async update(): Promise<void> {
         let mathLink = "";
-        console.log(`update(): entered: ${this.displayText}`);
         if (this.displayText != this.targetLink && this.displayText != translateLink(this.targetLink)) {
             // [[note|display]] -> use display as mathLink
-            console.log("update(): use display");
             mathLink = this.displayText;
         } else {
             const targetName = this.targetFile?.basename;
-            const targetDisplay = this.containerEl.innerText;
-            console.log(`targetName = ${targetName}`);
-            console.log(`targetDisplay = ${targetDisplay}`);
-            console.log(`this.targetLink = ${this.targetLink}`);
-            console.log(`translateLink(this.targetLink) = ${translateLink(this.targetLink)}`);
             if (this.displayText == targetName || this.displayText == translateLink(this.targetLink)) {
                 // [[note]], [[note#heading]] or [[note#^blockID]]
-                console.log("update(): go getMathLinks");
                 mathLink = getMathLink(this.plugin, this.targetLink, this.sourcePath);
             }
         }
 
-        console.log(`update: ${this.displayText}: mathLink = "${mathLink}"`);
         if (mathLink) {
             const children = await renderTextWithMathAsync(mathLink);
             this.containerEl.replaceChildren(...children);


### PR DESCRIPTION
I propose two options for resolving #35.

1. based on the previous release 0.4.1: This PR
2. based on the latest release 0.4.2: #36 

Please choose the one you prefer (if exists).

---

# Common modification

Both 1 & 2 have the following modification in common:

In `MathLinksRenderChild.update()`, `targetDisplay` should be replaced with `this.displayText` because the former is overwritten when `mathLink` is updated but the latter remains untouched.

Having `targetDisplay` seems to do little harm for mathLinks registered via the YAML frontmatter, but it is problematic for API mathLinks.

---

# Changes specific to this PR

There's not much of it. 
I'm not sure why the delay when opening files (the issue you've addressed in the latest release) is happening so there wasn't a lot that I can do for fixing it.

The only possible reason for the delay that I've came up with was that I was `await`ing for every piece of inline math in `renderTextWithMath`: https://github.com/zhaoshenzhai/obsidian-mathlinks/blob/af275b5426aa5727a073027684c22f3d887ee4f5/src/links.ts#L100

So I tried to change it so that it calls `finishRenderMath` only once:
https://github.com/RyotaUshio/obsidian-mathlinks/blob/a2a5fff8118640bc206811ef30c3c36d0d12ea61/src/links.ts#L104

P.S. In this PR, there is no `mathLink-internal-link`/``original-internal-link"` classes, unlike in #36 .

