### PR TITLE
API updates & bugfix around heading mathlinks

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,4 +1,4 @@
-import { App, MarkdownView, PluginManifest, TFile, WorkspaceLeaf } from 'obsidian';
+import { App, BlockSubpathResult, HeadingSubpathResult, MarkdownView, PluginManifest, TFile, WorkspaceLeaf } from 'obsidian';
 import MathLinks from '../main';
 
 export interface MathLinksMetadata {
@@ -11,7 +11,7 @@ export type MathLinksMetadataSet = Map<TFile, MathLinksMetadata>;
 export class MathLinksAPIAccount {
     metadataSet: MathLinksMetadataSet;
 
-    constructor(public plugin: MathLinks, public manifest: Readonly<PluginManifest>, public blockPrefix: string, public prefixer: (sourceFile: TFile, targetFile: TFile) => string | null) {
+    constructor(public plugin: MathLinks, public manifest: Readonly<PluginManifest>, public blockPrefix: string, public prefixer: (sourceFile: TFile, targetFile: TFile, subpathResult: HeadingSubpathResult | BlockSubpathResult) => string | null) {
         this.metadataSet = new Map();
     }
 

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -6,19 +6,19 @@ export interface MathLinksMetadata {
     "mathLink-blocks"?: Record<string, string>;
 }
 
-export type MathLinksMetadataSet = Record<string, MathLinksMetadata>;
+export type MathLinksMetadataSet = Map<TFile, MathLinksMetadata>;
 
 export class MathLinksAPIAccount {
     metadataSet: MathLinksMetadataSet;
 
-    constructor(public plugin: MathLinks, public manifest: Readonly<PluginManifest>, public blockPrefix: string, public enableFileNameBlockLinks: boolean) {
-        this.metadataSet = {};
+    constructor(public plugin: MathLinks, public manifest: Readonly<PluginManifest>, public blockPrefix: string, public prefixer: (sourceFile: TFile, targetFile: TFile) => string | null) {
+        this.metadataSet = new Map();
     }
 
-    get(path: string, blockID?: string): string | undefined {
+    get(file: TFile, blockID?: string): string | undefined {
         // If blockID === undefined, return mathLink
         // If blockID is given, return the corresponding item of mathLink-blocks
-        let metadata = this.metadataSet[path];
+        let metadata = this.metadataSet.get(file);
         if (metadata) {
             if (blockID === undefined) {
                 return metadata["mathLink"];
@@ -30,48 +30,47 @@ export class MathLinksAPIAccount {
         }
     }
 
-    update(path: string, newMetadata: MathLinksMetadata): void {
-        let file = this.plugin.app.vault.getAbstractFileByPath(path);
-        if (file instanceof TFile && file.extension == "md") {
-            this.metadataSet[path] = Object.assign({}, this.metadataSet[path], newMetadata);
-            informChange(this.plugin.app, "mathlinks:updated", this, path);
+    update(file: TFile, newMetadata: MathLinksMetadata): void {
+        if (file.extension == "md") {
+            this.metadataSet.set(file, Object.assign({}, this.metadataSet.get(file), newMetadata));
+            informChange(this.plugin.app, "mathlinks:updated", this, file);
         } else {
-            throw Error(`MathLinks API: Invalid path: ${path}`);
+            throw Error(`MathLinks API: ${this.manifest.name} passed a non-markdown file ${file.path} to update().`);
         }
     }
 
-    delete(path: string, which?: string): void {
+    delete(file: TFile, which?: string): void {
         // `which === undefined`: remove all the mathLinks associated with `path`
         // `which == "mathLink": remove `mathLink`
         // `which == "mathLink-blocks": remove `mathLink-blocks`
         // `which == <blockID>`: remove `mathLink-blocks[<blockID>]`
-        let metadata = this.metadataSet[path];
+        let metadata = this.metadataSet.get(file);
         if (metadata) {
             if (which === undefined) {
-                delete this.metadataSet[path];
+                this.metadataSet.delete(file);
             } else if (which == "mathLink" || which == "mathLink-blocks") {
                 if (metadata[which] !== undefined) {
                     delete metadata[which];
                 } else {
-                    throw Error(`MathLinks API: MathLinksMetadata of type "${which}" does not exist for ${path}`);
+                    throw Error(`MathLinks API: ${this.manifest.name} attempted to delete ${which} of ${file.path}, but it does not exist.`);
                 }
             } else {
                 let blocks = metadata["mathLink-blocks"];
                 if (blocks && blocks[which] !== undefined) {
                     delete blocks[which];
                 } else {
-                    throw Error(`MathLinks API: MathLinksMetadata for ${path}#^${which}" does not exist`);
+                    throw Error(`MathLinks API: ${this.manifest.name} attempted to delete mathLink-blocks for ${file.path}#^${which}", but it does not exist`);
                 }
             }
         } else {
-            throw Error(`MathLinks API: MathLinksMetadata for ${path} does not exist`);
+            throw Error(`MathLinks API: ${this.manifest.name} attempted to delete the MathLinks metadata of ${file.path}, but it does not exist.`);
         }
-        informChange(this.plugin.app, "mathlinks:updated", this, path);
+        informChange(this.plugin.app, "mathlinks:updated", this, file);
     }
 }
 
 // eventName: "mathlinks:updated" | "mathlinks:account-deleted"
-export function informChange(app: App, eventName: string, ...callbackArgs: [apiAccount: MathLinksAPIAccount, path?: string]) {
+export function informChange(app: App, eventName: string, ...callbackArgs: [apiAccount: MathLinksAPIAccount, file?: TFile]) {
     // trigger an event informing this update
     app.metadataCache.trigger(eventName, ...callbackArgs);
 

--- a/src/links/helper.ts
+++ b/src/links/helper.ts
@@ -47,8 +47,6 @@ export function getMathLink(plugin: MathLinks, targetLink: string, sourcePath: s
         }
     }
 
-    console.log(`targetLink = "${targetLink}", mathLink = "${mathLink}"`);
-
     if (!mathLink && plugin.settings.enableAPI) {
         const sourceFile = plugin.app.vault.getAbstractFileByPath(sourcePath);
         if (sourceFile instanceof TFile) {

--- a/src/links/helper.ts
+++ b/src/links/helper.ts
@@ -56,7 +56,7 @@ export function getMathLink(plugin: MathLinks, targetLink: string, sourcePath: s
                     if (subpathResult) {
                         mathLink = getMathLinkFromSubpath(path, subpathResult, metadata, account.blockPrefix,
                             // An API user can specify custom prefixes depending on the source file (sourceFile) & the target file (file).
-                            account.prefixer(sourceFile, file)
+                            account.prefixer(sourceFile, file, subpathResult)
                         );
                     } else {
                         mathLink = metadata["mathLink"] ?? "";

--- a/src/links/helper.ts
+++ b/src/links/helper.ts
@@ -34,20 +34,20 @@ export function getMathLink(plugin: MathLinks, targetLink: string, sourcePath: s
     let subpathResult = resolveSubpath(cache, subpath);
 
     let mathLink = "";
-    if (cache.frontmatter) {
-        if (subpathResult) {
-            mathLink = getMathLinkFromSubpath(path, subpathResult, cache.frontmatter, plugin.settings.blockPrefix, 
-                // If enableFileNameBlockLinks == true, pass `null` to the last parameter `prefix`, which means using the standard prefix (e.g. note > block). 
-                // Otherwise, pass an empty string to `prefix`, which means using no prefix (no prefix is a special case of custom prefixes).
-                plugin.settings.enableFileNameBlockLinks ? null : ""
-            );
-        } else if (path) {
-            mathLink = cache.frontmatter.mathLink;
-            if (mathLink == "auto") {
-                mathLink = getMathLinkFromTemplates(plugin, file);
-            }
+    if (subpathResult) {
+        mathLink = getMathLinkFromSubpath(path, subpathResult, cache.frontmatter, plugin.settings.blockPrefix,
+            // If enableFileNameBlockLinks == true, pass `null` to the last parameter `prefix`, which means using the standard prefix (e.g. note > block). 
+            // Otherwise, pass an empty string to `prefix`, which means using no prefix (no prefix is a special case of custom prefixes).
+            plugin.settings.enableFileNameBlockLinks ? null : ""
+        );
+    } else if (path) {
+        mathLink = cache.frontmatter?.mathLink;
+        if (mathLink == "auto") {
+            mathLink = getMathLinkFromTemplates(plugin, file);
         }
     }
+
+    console.log(`targetLink = "${targetLink}", mathLink = "${mathLink}"`);
 
     if (!mathLink && plugin.settings.enableAPI) {
         const sourceFile = plugin.app.vault.getAbstractFileByPath(sourcePath);
@@ -56,7 +56,7 @@ export function getMathLink(plugin: MathLinks, targetLink: string, sourcePath: s
                 const metadata = account.metadataSet.get(file);
                 if (metadata) {
                     if (subpathResult) {
-                        mathLink = getMathLinkFromSubpath(path, subpathResult, metadata, account.blockPrefix, 
+                        mathLink = getMathLinkFromSubpath(path, subpathResult, metadata, account.blockPrefix,
                             // An API user can specify custom prefixes depending on the source file (sourceFile) & the target file (file).
                             account.prefixer(sourceFile, file)
                         );
@@ -67,26 +67,26 @@ export function getMathLink(plugin: MathLinks, targetLink: string, sourcePath: s
                 if (mathLink) {
                     break;
                 }
-            }    
+            }
         }
     }
 
     return mathLink;
 }
 
-function getMathLinkFromSubpath(linkpath: string, subpathResult: HeadingSubpathResult | BlockSubpathResult, metadata: MathLinksMetadata, blockPrefix: string, prefix: string | null): string {
+function getMathLinkFromSubpath(linkpath: string, subpathResult: HeadingSubpathResult | BlockSubpathResult, metadata: MathLinksMetadata | undefined, blockPrefix: string, prefix: string | null): string {
     let subMathLink = ""
     if (subpathResult.type == "heading") {
         subMathLink = subpathResult.current.heading;
-    } else if (subpathResult.type == "block" && metadata["mathLink-blocks"] && metadata["mathLink-blocks"][subpathResult.block.id]) {
+    } else if (subpathResult.type == "block" && metadata?.["mathLink-blocks"]?.[subpathResult.block.id]) {
         subMathLink = blockPrefix + metadata["mathLink-blocks"][subpathResult.block.id];
     }
     if (subMathLink) {
         if (prefix === null) { // use standard prefix
             if (linkpath) {
-                return (metadata["mathLink"] ?? linkpath) + " > " + subMathLink;    
+                return (metadata?.["mathLink"] ?? linkpath) + " > " + subMathLink;
             } else {
-                return subMathLink;    
+                return subMathLink;
             }
         } else { // typeof prefix == 'string' => use custom prefix 
             return prefix + subMathLink;

--- a/src/links/reading.ts
+++ b/src/links/reading.ts
@@ -31,8 +31,8 @@ export class MathLinksRenderChild extends MarkdownRenderChild {
         }));
 
         // 2. when an API user updates its metadata
-        this.plugin.registerEvent(this.plugin.app.metadataCache.on("mathlinks:updated", (apiAccount, changedFilePath) => {
-            if (!this.targetFile || this.targetFile.path == changedFilePath) {
+        this.plugin.registerEvent(this.plugin.app.metadataCache.on("mathlinks:updated", (apiAccount, changedFile) => {
+            if (!this.targetFile || this.targetFile == changedFile) {
                 this.update();
             }
         }));

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
-import { FileView, MarkdownEditView, MarkdownView, Plugin, WorkspaceLeaf, loadMathJax } from "obsidian";
+import { FileView, Plugin, WorkspaceLeaf, loadMathJax } from "obsidian";
 import { MathLinksSettings, DEFAULT_SETTINGS } from "./settings/settings";
 import { MathLinksSettingTab } from "./settings/tab"
-import { MathLinksAPIAccount, informChange } from "./api/api";
+import { MathLinksAPIAccount } from "./api/api";
 import { generateMathLinks } from "./links/reading";
 import { buildLivePreview } from "./links/preview";
 import { isExcluded } from "./utils";
@@ -49,7 +49,7 @@ export default class MathLinks extends Plugin {
         let account = this.apiAccounts.find((account) => account.manifest.id == userPlugin.manifest.id);
         if (account) return account;
 
-        account = new MathLinksAPIAccount(this, userPlugin.manifest, DEFAULT_SETTINGS.blockPrefix, DEFAULT_SETTINGS.enableFileNameBlockLinks);
+        account = new MathLinksAPIAccount(this, userPlugin.manifest, DEFAULT_SETTINGS.blockPrefix, () => null);
         this.apiAccounts.push(account);
         return account;
     }

--- a/src/type.d.ts
+++ b/src/type.d.ts
@@ -1,5 +1,5 @@
 import { EditorView } from "@codemirror/view";
-import { MathLinksAPIAccount, MathLinksMetadata } from "./api/api";
+import { MathLinksAPIAccount } from "./api/api";
 import MathLinks from "./main";
 
 // Reference: 
@@ -36,7 +36,7 @@ declare module "obsidian" {
         // triggered when an API user updates its MathLinks metadata
         on(
             name: "mathlinks:updated",
-            callback: (apiAccount: MathLinksAPIAccount, path: string) => any
+            callback: (apiAccount: MathLinksAPIAccount, file: TFile) => any
         ): EventRef;
 
         // triggered when an API account is deleted


### PR DESCRIPTION
Hi @zhaoshenzhai! Let me propose a few updates to the API.

1. Generalize `enableFileNameBlockLinks: boolean`  to `prefixer: (sourceFile, targetFile) => string | null`.
2. Change `MathLinksMetadataSet` from `Record<string, MathLinksMetadata>` to `Map<TFile, MathLinksMetadata>` in order to better react to file renaming/deletion.

I'll explain these changes below. What are your thoughts? I'd love to hear your feedback when you have time.

## Prefixer

This update is about the prepended note title before a heading/block MathLink (`note > heading`).
I believe it gives the API users much more flexibility.

Firstly, `getMathLinkFromSubpath`'s last parameter is now `prefix: string | null`.

https://github.com/RyotaUshio/obsidian-mathlinks/blob/3cd5bc8011ec5572925e393394d6cf3d97058ff9/src/links/helper.ts#L77-L97

- If `prefix` is `null`, the standard prefix rule is applied. That is, the note title (or `mathLink` if it exists) + ` > ` is used as the prefix.
- On the other hand, if `prefix` is `string`, then it is interpreted as a custom prefix. In other words, the resulting `mathLink` is `prefix + subMathLink`.

Secondly, each API account's `enableFileNameBlockLinks: boolean` property has been replaced with a function `prefixer: (sourceFile: TFile, targetFile: TFile) => string | null`, which determines the value of `prefix` (`getMathLinkFromSubpath`'s last parameter) depending on the relationship between `sourceFile` (where the link exists) and `targetFile` (where the link goes).

https://github.com/RyotaUshio/obsidian-mathlinks/blob/3cd5bc8011ec5572925e393394d6cf3d97058ff9/src/links/helper.ts#L59-L62

The default behavior can be recovered by setting `prefixer` to be`() => null`: 
https://github.com/RyotaUshio/obsidian-mathlinks/blob/3cd5bc8011ec5572925e393394d6cf3d97058ff9/src/main.ts#L52

Moreover, it can be used to realize much more flexible behavior. For example, 

https://github.com/RyotaUshio/obsidian-math-booster/blob/refactor/docs/projects.md

this feature (unreleased, but you can try using the `refactor` branch of Math Booster if you are interested) can be realized with the following `prefixer`:

https://github.com/RyotaUshio/obsidian-math-booster/blob/44881ee182e3194dbc5b0fb30ba135fd0cc2dc37/src/project.ts#L123-L141

As for the ordinary mathlinks (given in frontmatter), the current behavior can be recovered by setting `getMathLinkFromSubpath`'s `prefix` parameter to be `plugin.settings.enableFileNameBlockLinks ? null : ""`:

https://github.com/RyotaUshio/obsidian-mathlinks/blob/3cd5bc8011ec5572925e393394d6cf3d97058ff9/src/links/helper.ts#L39-L43

## Record to Map

Currently, each `MathLinksAPIAccount`'s `metadataSet: MathLinksMetadataSet` is implemented by `Record<string, MathLinksMetadata>` i.e. a dictionary that maps a file path to the corresponding metadata.

The problem is that, even after a file is renamed or deleted, its metadata remains as is because there isn't anything that handles this kind of event.

Although it's not a big issue at least for my plugin, it can be problematic for other plugins that will use the API in the future.

There are at least two possible solutions for this issue:

1. Add event handlers for file renaming & deletion
2. Replace file paths (`string`) with `TFile` objects (which keep pointing to the same file after renaming or deletion)

Here I chose the second one because it eliminates the need for manual implementation of event handlers, which can be buggy.

Record doesn't accept TFile as a key value, so I had to use Map instead.