### PR TITLE
update the paths of API entry point & typing

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
     "name": "obsidian-mathlinks",
     "version": "0.4.5",
     "description": "Render MathJax in your links",
-    "main": "lib/index.js",
-    "types": "lib/index.d.ts",
+    "main": "lib/api/index.js",
+    "types": "lib/api/index.d.ts",
     "files": [
         "lib/**/*"
     ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "obsidian-mathlinks",
-    "version": "0.4.5",
+    "version": "0.4.6",
     "description": "Render MathJax in your links",
     "main": "lib/api/index.js",
     "types": "lib/api/index.d.ts",


### PR DESCRIPTION
Now that `index.ts` has moved to `src/api`, we have to update `main` & `types` fields of `package.json` accordingly.

@zhaoshenzhai Sorry to bother you but please re-update the `npm` package after merging this PR!