### PR TITLE
fix #51

### DIFF
--- a/src/links/reading.ts
+++ b/src/links/reading.ts
@@ -16,6 +16,7 @@ export class MathLinksRenderChild extends MarkdownRenderChild {
         this.containerEl.parentNode?.insertBefore(this.mathLinkEl, this.containerEl.nextSibling);
         this.mathLinkEl.classList.add("mathLink-internal-link");
         this.containerEl.classList.add("original-internal-link");
+        this.containerEl.classList.remove("internal-link"); // #51: this is to fix the incompatibility with Strange New Worlds
         this.containerEl.style.display = "none";
         this.getMathLink = this.setMathLinkGetter();
     }


### PR DESCRIPTION
This PR resolves #51.

All I've done is simply remove the `.internal-link` class from `.original-internal-link` element.
It seems to suffice to fix the issue because the `MarkdownPostProcessor` of Strange New Worlds finds its target elements with `querySelectorAll("a.internal-link:not(.snw-link-preview)")`:

https://github.com/TfTHacker/obsidian42-strange-new-worlds/blob/48a4d547a653aaefab76214ab9b0e573f167babe/src/view-extensions/references-preview.ts#L153

@zhaoshenzhai Hi, in my quick test, Dataview inline fields (which were the only concern) are rendered without any problems after this change.
I'd like to check the compatibility issues with other plugins as well, but the plugin folders in the test vault seem to lack `main.js`.

What is the intention of this? How do you usually test them in the test vault? (I'm aware of `makefile`, but it has nothing to do with other plugins than MathLinks, so)