### PR TITLE
API renewal & sample plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,10 @@ MathLinks supports links to blocks and headings like `[[note#^block-id]]` and `[
 * Editing the prefix for block links: By default, block links are prefixed by `^`. This can be changed (or removed).
 * Toggling whether to render `note`: If disabled, the links will be rendered as `[[^block-id]]` and `[[section]]`.
 
-### Enable API
-Expose some of `MathLinks`' features to other community plugins. Enabled by default.
+## MathLinks API
+
+MathLinks exposes an API, allowing other community plugins to utilize its powerful "dynamic aliases" feature.
+You can find more information & a simple sample plugin at this repo: https://github.com/RyotaUshio/obsidian-mathlinks-api-sample-plugin
 
 ## Contributing
 If you would like to point out a bug, add support, or have a feature request, don't hesitate to open an issue/pull request! Thank you to all who have contributed.

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,5 +1,6 @@
-import { App, BlockSubpathResult, HeadingSubpathResult, MarkdownView, PluginManifest, TFile, WorkspaceLeaf } from 'obsidian';
+import { BlockSubpathResult, HeadingSubpathResult, PluginManifest, TFile } from 'obsidian';
 import MathLinks from '../main';
+import { informChange } from 'src/utils';
 
 export interface MathLinksMetadata {
     "mathLink"?: string;
@@ -67,17 +68,4 @@ export class MathLinksAPIAccount {
         }
         informChange(this.plugin.app, "mathlinks:update", file);
     }
-}
-
-// eventName: see src/type.d.ts
-export function informChange(app: App, eventName: string, ...callbackArgs: [file?: TFile]) {
-    // trigger an event informing this update
-    app.metadataCache.trigger(eventName, ...callbackArgs);
-
-    // refresh mathLinks display based on the new metadata
-    app.workspace.iterateRootLeaves((leaf: WorkspaceLeaf) => {
-        if (leaf.view instanceof MarkdownView && leaf.view.getMode() == 'source') {
-            leaf.view.editor.cm?.dispatch();
-        }
-    });
 }

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -33,7 +33,7 @@ export class MathLinksAPIAccount {
     update(file: TFile, newMetadata: MathLinksMetadata): void {
         if (file.extension == "md") {
             this.metadataSet.set(file, Object.assign({}, this.metadataSet.get(file), newMetadata));
-            informChange(this.plugin.app, "mathlinks:updated", this, file);
+            informChange(this.plugin.app, "mathlinks:update", file);
         } else {
             throw Error(`MathLinks API: ${this.manifest.name} passed a non-markdown file ${file.path} to update().`);
         }
@@ -65,12 +65,12 @@ export class MathLinksAPIAccount {
         } else {
             throw Error(`MathLinks API: ${this.manifest.name} attempted to delete the MathLinks metadata of ${file.path}, but it does not exist.`);
         }
-        informChange(this.plugin.app, "mathlinks:updated", this, file);
+        informChange(this.plugin.app, "mathlinks:update", file);
     }
 }
 
-// eventName: "mathlinks:updated" | "mathlinks:account-deleted"
-export function informChange(app: App, eventName: string, ...callbackArgs: [apiAccount: MathLinksAPIAccount, file?: TFile]) {
+// eventName: see src/type.d.ts
+export function informChange(app: App, eventName: string, ...callbackArgs: [file?: TFile]) {
     // trigger an event informing this update
     app.metadataCache.trigger(eventName, ...callbackArgs);
 

--- a/src/api/deprecated.ts
+++ b/src/api/deprecated.ts
@@ -1,3 +1,7 @@
+/**
+ * This files the obsolete API. Use the new API in provider.ts instead.
+ */
+
 import { BlockSubpathResult, HeadingSubpathResult, PluginManifest, TFile } from 'obsidian';
 import MathLinks from '../main';
 import { informChange } from 'src/utils';

--- a/src/api/deprecated.ts
+++ b/src/api/deprecated.ts
@@ -1,5 +1,5 @@
 /**
- * This files the obsolete API. Use the new API in provider.ts instead.
+ * This files contains the obsolete API. Use the new API in provider.ts instead.
  */
 
 import { BlockSubpathResult, HeadingSubpathResult, PluginManifest, TFile } from 'obsidian';

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -7,7 +7,7 @@ import { Provider } from "./provider";
 import MathLinks from "../main";
 
 
-export function addProvider(app: App, providerFactory: (mathLinks: MathLinks) => Provider): Provider {
+export function addProvider<CustomProvider extends Provider>(app: App, providerFactory: (mathLinks: MathLinks) => CustomProvider): CustomProvider {
     if (!isPluginEnabled(app)) throw Error("MathLinks API: MathLinks is not enabled.");
     const mathLinks = app.plugins.plugins.mathlinks as MathLinks;
     const provider = providerFactory(mathLinks);

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -2,9 +2,10 @@ export type { MathLinksMetadata, MathLinksMetadataSet, MathLinksAPIAccount } fro
 export { Provider } from './provider';
 
 import { TFile, type App, type Plugin } from "obsidian";
-import { MathLinksAPIAccount, informChange } from "./api";
+import { MathLinksAPIAccount } from "./api";
 import { Provider } from "./provider";
 import MathLinks from "../main";
+import { informChange } from "src/utils";
 
 
 export function addProvider<CustomProvider extends Provider>(app: App, providerFactory: (mathLinks: MathLinks) => CustomProvider): CustomProvider {
@@ -32,7 +33,6 @@ export function update(app: App, file?: TFile) {
     }
 }
 
-
 /**
  * Obsolete & Deprecated API
  */
@@ -57,6 +57,6 @@ export const deleteAPIAccount = (userPlugin: Readonly<Plugin>): void => {
             (account) => account.manifest.id == userPlugin.manifest.id
         );
         accounts.splice(index, 1);
-        informChange(userPlugin.app, "mathlinks:update-all");
+        update(userPlugin.app);
     }
 }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,8 +1,8 @@
-export type { MathLinksMetadata, MathLinksMetadataSet, MathLinksAPIAccount } from "./api";
+export type { MathLinksMetadata, MathLinksMetadataSet, MathLinksAPIAccount } from "./deprecated";
 export { Provider } from './provider';
 
 import { TFile, type App, type Plugin } from "obsidian";
-import { MathLinksAPIAccount } from "./api";
+import { MathLinksAPIAccount } from "./deprecated";
 import { Provider } from "./provider";
 import MathLinks from "../main";
 import { informChange } from "src/utils";

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -47,7 +47,8 @@ export function getAPIAccount(userPlugin: Readonly<Plugin>): MathLinksAPIAccount
 }
 
 /**
- * Previously, a user plugin had to call this when unloading, but now it has no effect.
+ * This function is obsolete and You don't call this function no more.
+ * It will be removed in a future version.
  */
 export const deleteAPIAccount = (userPlugin: Readonly<Plugin>): void => {
     let accounts = userPlugin.app.plugins.plugins.mathlinks?.apiAccounts;
@@ -55,7 +56,6 @@ export const deleteAPIAccount = (userPlugin: Readonly<Plugin>): void => {
         let index = accounts.findIndex(
             (account) => account.manifest.id == userPlugin.manifest.id
         );
-        let account = accounts[index];
         accounts.splice(index, 1);
         informChange(userPlugin.app, "mathlinks:update-all");
     }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -5,7 +5,7 @@ import { TFile, type App, type Plugin } from "obsidian";
 import { MathLinksAPIAccount } from "./deprecated";
 import { Provider } from "./provider";
 import MathLinks from "../main";
-import { informChange } from "src/utils";
+import { informChange } from "../utils";
 
 
 export function addProvider<CustomProvider extends Provider>(app: App, providerFactory: (mathLinks: MathLinks) => CustomProvider): CustomProvider {

--- a/src/api/provider.ts
+++ b/src/api/provider.ts
@@ -1,0 +1,95 @@
+import { MathLinksAPIAccount, informChange } from './api';
+import { BlockSubpathResult, Component, HeadingSubpathResult, TFile } from 'obsidian';
+import { getMathLinkFromSubpath, getMathLinkFromTemplates } from '../links/helper';
+import MathLinks from '../main';
+
+/**
+ * A class that provides a displayed text for a given link.
+ */
+export abstract class Provider extends Component {
+    constructor(public mathLinks: MathLinks) {
+        super();
+    }
+
+    public abstract provide(
+        parsedLinktext: { path: string, subpath: string },
+        targetFile: TFile | null,
+        targetSubpathResult: HeadingSubpathResult | BlockSubpathResult | null,
+        sourceFile: TFile
+    ): string | null;
+
+    onunload() {
+        const providers = this.mathLinks.providers;
+        let index = providers.findIndex(({ provider }) => provider === this);
+        providers.splice(index, 1);
+        informChange(this.mathLinks.app, "mathlinks:update-all");
+    }
+}
+
+export class NativeProvider extends Provider {
+    public provide(
+        parsedLinktext: { path: string, subpath: string },
+        targetFile: TFile | null,
+        targetSubpathResult: HeadingSubpathResult | BlockSubpathResult | null,
+        sourceFile: TFile
+    ): string | null {
+        const { mathLinks } = this;
+        const { app } = mathLinks;
+
+        if (!targetFile) return null;
+
+        let cache = app.metadataCache.getFileCache(targetFile);
+        if (!cache) return null;
+
+        let mathLink: string | null = null;
+        if (targetSubpathResult) {
+            mathLink = getMathLinkFromSubpath(parsedLinktext.path, targetSubpathResult, cache.frontmatter, mathLinks.settings.blockPrefix,
+                // If enableFileNameBlockLinks == true, pass `null` to the last parameter `prefix`, which means using the standard prefix (e.g. note > block). 
+                // Otherwise, pass an empty string to `prefix`, which means using no prefix (no prefix is a special case of custom prefixes).
+                mathLinks.settings.enableFileNameBlockLinks ? null : ""
+            );
+        } else if (parsedLinktext.path) {
+            mathLink = cache.frontmatter?.mathLink;
+            if (mathLink == "auto") {
+                mathLink = getMathLinkFromTemplates(mathLinks, targetFile);
+            }
+        }
+
+        return mathLink;
+    }
+}
+
+/**
+ * Provider for preserving backward compatibility with the deprecated API.
+ */
+export class DeprecatedAPIProvider extends Provider {
+    constructor(public account: MathLinksAPIAccount) {
+        super(account.plugin);
+    }
+
+    public provide(
+        parsedLinktext: { path: string, subpath: string },
+        targetFile: TFile | null,
+        targetSubpathResult: HeadingSubpathResult | BlockSubpathResult | null,
+        sourceFile: TFile
+    ): string | null {
+        if (targetFile === null) {
+            return null;
+        }
+
+        let mathLink: string | null = null;
+        const metadata = this.account.metadataSet.get(targetFile);
+        if (metadata) {
+            if (targetSubpathResult) {
+                mathLink = getMathLinkFromSubpath(parsedLinktext.path, targetSubpathResult, metadata, this.account.blockPrefix,
+                    // An API user can specify custom prefixes depending on the source file (sourceFile) & the target file (file).
+                    this.account.prefixer(sourceFile, targetFile, targetSubpathResult)
+                );
+            } else {
+                mathLink = metadata["mathLink"] ?? null;
+            }
+        }
+
+        return mathLink;
+    }
+}

--- a/src/api/provider.ts
+++ b/src/api/provider.ts
@@ -1,4 +1,4 @@
-import { MathLinksAPIAccount } from './api';
+import { MathLinksAPIAccount } from './deprecated';
 import { BlockSubpathResult, Component, HeadingSubpathResult, TFile } from 'obsidian';
 import { getMathLinkFromSubpath, getMathLinkFromTemplates } from '../links/helper';
 import { update } from './index';

--- a/src/api/provider.ts
+++ b/src/api/provider.ts
@@ -1,14 +1,26 @@
 import { MathLinksAPIAccount, informChange } from './api';
 import { BlockSubpathResult, Component, HeadingSubpathResult, TFile } from 'obsidian';
 import { getMathLinkFromSubpath, getMathLinkFromTemplates } from '../links/helper';
+import { update } from './index';
 import MathLinks from '../main';
 
 /**
  * A class that provides a displayed text for a given link.
  */
 export abstract class Provider extends Component {
+    _enableInSourceMode: boolean = false;
+
     constructor(public mathLinks: MathLinks) {
         super();
+    }
+
+    get enableInSourceMode() {
+        return this._enableInSourceMode;
+    }
+
+    set enableInSourceMode(enable: boolean) {
+        this._enableInSourceMode = enable;
+        update(this.mathLinks.app);
     }
 
     public abstract provide(
@@ -27,6 +39,16 @@ export abstract class Provider extends Component {
 }
 
 export class NativeProvider extends Provider {
+    get enableInSourceMode() {
+        return this.mathLinks.settings.enableInSourceMode;
+    }
+
+    set enableInSourceMode(enable: boolean) {
+        this.mathLinks.settings.enableInSourceMode = enable;
+        update(this.mathLinks.app);
+        this.mathLinks.saveSettings();
+    }
+
     public provide(
         parsedLinktext: { path: string, subpath: string },
         targetFile: TFile | null,

--- a/src/api/provider.ts
+++ b/src/api/provider.ts
@@ -1,4 +1,4 @@
-import { MathLinksAPIAccount, informChange } from './api';
+import { MathLinksAPIAccount } from './api';
 import { BlockSubpathResult, Component, HeadingSubpathResult, TFile } from 'obsidian';
 import { getMathLinkFromSubpath, getMathLinkFromTemplates } from '../links/helper';
 import { update } from './index';
@@ -27,14 +27,14 @@ export abstract class Provider extends Component {
         parsedLinktext: { path: string, subpath: string },
         targetFile: TFile | null,
         targetSubpathResult: HeadingSubpathResult | BlockSubpathResult | null,
-        sourceFile: TFile
+        sourceFile: TFile | null,
     ): string | null;
 
     onunload() {
         const providers = this.mathLinks.providers;
         let index = providers.findIndex(({ provider }) => provider === this);
         providers.splice(index, 1);
-        informChange(this.mathLinks.app, "mathlinks:update-all");
+        update(this.mathLinks.app);
     }
 }
 
@@ -52,8 +52,7 @@ export class NativeProvider extends Provider {
     public provide(
         parsedLinktext: { path: string, subpath: string },
         targetFile: TFile | null,
-        targetSubpathResult: HeadingSubpathResult | BlockSubpathResult | null,
-        sourceFile: TFile
+        targetSubpathResult: HeadingSubpathResult | BlockSubpathResult | null
     ): string | null {
         const { mathLinks } = this;
         const { app } = mathLinks;
@@ -93,9 +92,9 @@ export class DeprecatedAPIProvider extends Provider {
         parsedLinktext: { path: string, subpath: string },
         targetFile: TFile | null,
         targetSubpathResult: HeadingSubpathResult | BlockSubpathResult | null,
-        sourceFile: TFile
+        sourceFile: TFile | null,
     ): string | null {
-        if (targetFile === null) {
+        if (targetFile === null || sourceFile === null) {
             return null;
         }
 

--- a/src/links/helper.ts
+++ b/src/links/helper.ts
@@ -1,6 +1,6 @@
 import { NativeProvider } from './../api/provider';
 import { TFile, renderMath, finishRenderMath, parseLinktext, resolveSubpath, BlockSubpathResult, HeadingSubpathResult } from "obsidian";
-import { MathLinksMetadata } from "../api/api";
+import { MathLinksMetadata } from "../api/deprecated";
 import MathLinks from "../main";
 
 export function setMathLink(source: string, mathLinkEl: HTMLElement) {

--- a/src/links/helper.ts
+++ b/src/links/helper.ts
@@ -43,7 +43,7 @@ export function getMathLink(plugin: MathLinks, targetLink: string, sourcePath: s
     plugin.iterateProviders((provider) => {
         const provided = provider.provide({ path, subpath }, file, subpathResult, sourceFile);
         if (provided) {
-            if (provider instanceof NativeProvider && subpathResult.type == 'heading') {
+            if (provider instanceof NativeProvider && subpathResult?.type == 'heading') {
                 if (provided == (path ? path + ' > ' : '') + subpathResult.current.heading) {
                     return;
                 }

--- a/src/links/helper.ts
+++ b/src/links/helper.ts
@@ -1,3 +1,4 @@
+import { NativeProvider } from './../api/provider';
 import { TFile, renderMath, finishRenderMath, parseLinktext, resolveSubpath, BlockSubpathResult, HeadingSubpathResult } from "obsidian";
 import { MathLinksMetadata } from "../api/api";
 import MathLinks from "../main";
@@ -33,46 +34,28 @@ export function getMathLink(plugin: MathLinks, targetLink: string, sourcePath: s
 
     let subpathResult = resolveSubpath(cache, subpath);
 
-    let mathLink = "";
-    if (subpathResult) {
-        mathLink = getMathLinkFromSubpath(path, subpathResult, cache.frontmatter, plugin.settings.blockPrefix,
-            // If enableFileNameBlockLinks == true, pass `null` to the last parameter `prefix`, which means using the standard prefix (e.g. note > block). 
-            // Otherwise, pass an empty string to `prefix`, which means using no prefix (no prefix is a special case of custom prefixes).
-            plugin.settings.enableFileNameBlockLinks ? null : ""
-        );
-    } else if (path) {
-        mathLink = cache.frontmatter?.mathLink;
-        if (mathLink == "auto") {
-            mathLink = getMathLinkFromTemplates(plugin, file);
-        }
+    const sourceFile = plugin.app.vault.getAbstractFileByPath(sourcePath);
+    if (!(sourceFile instanceof TFile)) {
+        return "";
     }
 
-    if (!mathLink && plugin.settings.enableAPI) {
-        const sourceFile = plugin.app.vault.getAbstractFileByPath(sourcePath);
-        if (sourceFile instanceof TFile) {
-            for (let account of plugin.apiAccounts) {
-                const metadata = account.metadataSet.get(file);
-                if (metadata) {
-                    if (subpathResult) {
-                        mathLink = getMathLinkFromSubpath(path, subpathResult, metadata, account.blockPrefix,
-                            // An API user can specify custom prefixes depending on the source file (sourceFile) & the target file (file).
-                            account.prefixer(sourceFile, file, subpathResult)
-                        );
-                    } else {
-                        mathLink = metadata["mathLink"] ?? "";
-                    }
-                }
-                if (mathLink) {
-                    break;
+    let mathLink = "";
+    plugin.iterateProviders((provider) => {
+        const provided = provider.provide({ path, subpath }, file, subpathResult, sourceFile);
+        if (provided) {
+            if (provider instanceof NativeProvider && subpathResult.type == 'heading') {
+                if (provided == (path ? path + ' > ' : '') + subpathResult.current.heading) {
+                    return;
                 }
             }
+            mathLink = provided;
         }
-    }
+    });
 
     return mathLink;
 }
 
-function getMathLinkFromSubpath(linkpath: string, subpathResult: HeadingSubpathResult | BlockSubpathResult, metadata: MathLinksMetadata | undefined, blockPrefix: string, prefix: string | null): string {
+export function getMathLinkFromSubpath(linkpath: string, subpathResult: HeadingSubpathResult | BlockSubpathResult, metadata: MathLinksMetadata | undefined, blockPrefix: string, prefix: string | null): string {
     let subMathLink = ""
     if (subpathResult.type == "heading") {
         subMathLink = subpathResult.current.heading;
@@ -94,7 +77,7 @@ function getMathLinkFromSubpath(linkpath: string, subpathResult: HeadingSubpathR
     }
 }
 
-function getMathLinkFromTemplates(plugin: MathLinks, file: TFile): string {
+export function getMathLinkFromTemplates(plugin: MathLinks, file: TFile): string {
     let templates = plugin.settings.templates;
     let mathLink = file.name.replace(/\.md$/, "");
     for (let i = 0; i < templates.length; i++) {

--- a/src/links/helper.ts
+++ b/src/links/helper.ts
@@ -46,7 +46,7 @@ export function getMathLink(plugin: MathLinks, targetLink: string, sourcePath: s
         const provided = provider.provide({ path, subpath }, file, subpathResult, sourceFile);
         if (provided) {
             if (provider instanceof NativeProvider && subpathResult?.type == 'heading') {
-                if (provided == (path ? path + ' > ' : '') + subpathResult.current.heading) {
+                if (mathLink && provided == (path ? path + ' > ' : '') + subpathResult.current.heading) {
                     return;
                 }
             }

--- a/src/links/helper.ts
+++ b/src/links/helper.ts
@@ -23,7 +23,7 @@ export function setMathLink(source: string, mathLinkEl: HTMLElement) {
     if (textFrom < source.length) mathLinkEl.createSpan().replaceWith(source.slice(textFrom));
 }
 
-export function getMathLink(plugin: MathLinks, targetLink: string, sourcePath: string): string {
+export function getMathLink(plugin: MathLinks, targetLink: string, sourcePath: string, isSourceMode?: boolean): string {
     let { path, subpath } = parseLinktext(targetLink);
 
     let file = plugin.app.metadataCache.getFirstLinkpathDest(path, sourcePath);
@@ -41,6 +41,8 @@ export function getMathLink(plugin: MathLinks, targetLink: string, sourcePath: s
 
     let mathLink = "";
     plugin.iterateProviders((provider) => {
+        if (isSourceMode && !provider.enableInSourceMode) return;
+
         const provided = provider.provide({ path, subpath }, file, subpathResult, sourceFile);
         if (provided) {
             if (provider instanceof NativeProvider && subpathResult?.type == 'heading') {

--- a/src/links/preview.ts
+++ b/src/links/preview.ts
@@ -1,48 +1,181 @@
+import { Keymap, editorInfoField, editorLivePreviewField, getLinkpath } from "obsidian";
+import { Transaction, EditorState, RangeSet, RangeSetBuilder, RangeValue, StateEffect, StateEffectType, StateField, EditorSelection, Extension } from "@codemirror/state";
+import {
+    Decoration,
+    DecorationSet,
+    EditorView,
+    PluginValue,
+    ViewPlugin,
+    ViewUpdate,
+    WidgetType,
+} from "@codemirror/view";
+import MathLinks from '../main';
 import { syntaxTree } from "@codemirror/language";
-import { RangeSetBuilder } from "@codemirror/state";
-import { Decoration, DecorationSet, ViewUpdate, EditorView, ViewPlugin, WidgetType, PluginValue } from "@codemirror/view";
-import { FileView, MarkdownView, WorkspaceLeaf, TFile, getLinkpath, Keymap, editorLivePreviewField } from "obsidian";
 import { getMathLink, setMathLink } from "./helper";
 import { addSuperCharged } from "./supercharged";
-import { isExcluded } from "../utils";
-import MathLinks from "../main";
 
-export function buildLivePreview<V extends PluginValue>(plugin: MathLinks, leaf: WorkspaceLeaf): Promise<ViewPlugin<V>> {
-    let leafView = leaf.view as FileView;
 
-    class MathWidget extends WidgetType {
-        constructor(public outLinkText: string, public outLinkMathLink: string, public isSourceMode?: boolean) { super(); }
+function selectionAndRangeOverlap(selection: EditorSelection, rangeFrom: number, rangeTo: number): boolean {
+    for (const range of selection.ranges) {
+        if (range.from <= rangeTo && range.to >= rangeFrom) {
+            return true;
+        }
+    }
+    return false;
+}
 
-        toDOM() {
-            let mathLink = document.createElement("span");
-            setMathLink(this.outLinkMathLink, mathLink);
-            if (!this.isSourceMode) mathLink.classList.add("cm-underline");
-            mathLink.setAttribute("draggable", "true");
+function hasEffect<T>(tr: Transaction, effectType: StateEffectType<T>): boolean {
+    return tr.effects.some(effect => effect.is(effectType));
+}
 
-            let outLinkFile = plugin.app.metadataCache.getFirstLinkpathDest(this.outLinkText.replace(/#.*$/, ""), "");
-            if (outLinkFile) addSuperCharged(plugin, mathLink, outLinkFile);
+export const forceUpdateEffect = StateEffect.define<null>();
 
-            let mathLinkWrapper = document.createElement("span");
-            mathLinkWrapper.classList.add("cm-hmd-internal-link");
-            mathLinkWrapper.appendChild(mathLink);
+class MathLinkInfo extends RangeValue {
+    constructor(public linkText: string, public mathLink: string) {
+        super();
+    }
 
-            let sourcePath = "";
-            if (leafView.file) {
-                sourcePath = leafView.file.path;
-                if (sourcePath.endsWith(".canvas")) {
-                    for (let node of leafView.canvas.selection.values()) {
-                        sourcePath = node.filePath;
-                        break;
+    eq(other: MathLinkInfo): boolean {
+        return this.linkText == other.linkText && this.mathLink == other.mathLink;
+    }
+}
+
+
+export const createEditorExtensions = (plugin: MathLinks): Extension[] => {
+
+    const buildField = (state: EditorState): RangeSet<MathLinkInfo> => {
+        let builder = new RangeSetBuilder<MathLinkInfo>();
+        const isSourceMode = !state.field(editorLivePreviewField);
+        const file = state.field(editorInfoField).file;
+
+        let start = -1, end = -1, outLinkText = "", outLinkMathLink = "";
+
+        syntaxTree(state).iterate({
+            enter(node) {
+                let name = node.type.name;
+
+                // Start
+                if (name.contains("formatting-link_formatting-link-start")) {
+                    if (isSourceMode) {
+                        if (state.sliceDoc(node.from, node.to) == "[[" && node.node.nextSibling) {
+                            start = node.node.nextSibling.from;
+                        } else {
+                            return;
+                        }    
+                    } else {
+                        start = node.from;
+                    }
+                }
+
+                // Start (check that it is not end)
+                else if (name.contains("formatting_formatting-link_link")) {
+                    if (start == -1) {
+                        start = node.from;
+                    }
+                }
+
+                // Alias: File name
+                else if (name.contains("has-alias")) {
+                    outLinkText += state.doc.sliceString(node.from, node.to);
+                    if (file && outLinkMathLink == outLinkText.replace(/\.md/, "")) {
+                        outLinkMathLink = getMathLink(plugin, outLinkText, file.path, isSourceMode);
+                    }
+                }
+
+                // Alias: File name (with decoding)
+                else if (/string_url$/.test(name) && !name.contains("format")) {
+                    outLinkText += decodeURI(state.doc.sliceString(node.from, node.to));
+                    if (file && outLinkMathLink == outLinkText.replace(/\.md/, "")) {
+                        outLinkMathLink = getMathLink(plugin, outLinkText, file.path, isSourceMode);
+                    }
+                }
+
+                // No alias
+                else if (file && name.contains("hmd-internal-link") && !name.contains("alias")) {
+                    outLinkText += state.doc.sliceString(node.from, node.to);
+                    outLinkMathLink = getMathLink(plugin, outLinkText, file.path, isSourceMode);
+                }
+
+                // End
+                else if (name.contains("formatting-link-end") || name.contains("formatting-link-string")) {
+                    if (!name.contains("end") && end == -1) {
+                        end = -2;
+                    } else {
+                        if (isSourceMode) {
+                            if (node.node.prevSibling && state.sliceDoc(node.from, node.to) == "]]") {
+                                end = node.node.prevSibling.to;
+                            } else {
+                                return;
+                            }
+                        } else {
+                            end = node.to;
+                        }
+
+                        let cursorRange = state.selection.main;
+                        if (start > cursorRange.to || end < cursorRange.from) {
+                            if (outLinkText && outLinkMathLink) {
+                                builder.add(
+                                    start,
+                                    end,
+                                    new MathLinkInfo(outLinkText, outLinkMathLink.replace(/\\\$/, "$")),
+                                );
+                            }
+                        }
+                        start = -1;
+                        end = -1;
+                        outLinkText = "";
+                        outLinkMathLink = "";
+                    }
+                }
+
+                // Alias: MathLink
+                else if (!name.contains("pipe") && ((name.contains("hmd-internal-link") && name.contains("alias")) || (name.contains("hmd-escape") && name.contains("link")) || /^link/.test(name))) {
+                    outLinkMathLink += state.doc.sliceString(node.from, node.to);
+                    if (file && outLinkMathLink == outLinkText.replace(/\.md/, "")) {
+                        outLinkMathLink = getMathLink(plugin, outLinkText, file.path, isSourceMode);
                     }
                 }
             }
+        });
 
-            const targetFile = plugin.app.metadataCache.getFirstLinkpathDest(getLinkpath(this.outLinkText), sourcePath);
+        return builder.finish();
+    }
+
+
+    /** A state field that stores links and their positions as a range set. */
+    const mathLinkInfoField = StateField.define<RangeSet<MathLinkInfo>>({
+        create: buildField,
+        update(oldFields, tr) {
+            return tr.docChanged || hasEffect(tr, forceUpdateEffect) ? buildField(tr.state) : oldFields;
+        }
+    });
+
+
+    class MathWidget extends WidgetType {
+        constructor(public outLinkText: string, public outLinkMathLink: string, public isSourceMode: boolean, public sourcePath: string) { super(); }
+
+        eq(other: MathWidget) {
+            return this.outLinkText == other.outLinkText && this.outLinkMathLink == other.outLinkMathLink && this.isSourceMode == other.isSourceMode && this.sourcePath == other.sourcePath;
+        }
+
+        toDOM() {
+            let mathLink = createSpan();
+            setMathLink(this.outLinkMathLink, mathLink);
+            if (!this.isSourceMode) mathLink.addClass("cm-underline");
+            mathLink.setAttribute("draggable", "true");
+
+            const linkpath = getLinkpath(this.outLinkText);
+            const targetFile = plugin.app.metadataCache.getFirstLinkpathDest(linkpath, this.sourcePath);
+            if (targetFile) addSuperCharged(plugin, mathLink, targetFile);
+
+            let mathLinkWrapper = createSpan();
+            mathLinkWrapper.addClass("cm-hmd-internal-link");
+            mathLinkWrapper.appendChild(mathLink);
 
             mathLinkWrapper.onclick = ((evt: MouseEvent) => {
                 evt.preventDefault();
                 if (targetFile) {
-                    plugin.app.workspace.openLinkText(this.outLinkText, sourcePath, Keymap.isModEvent(evt));
+                    plugin.app.workspace.openLinkText(this.outLinkText, this.sourcePath, Keymap.isModEvent(evt));
                 } else {
                     self.open(this.outLinkText, "_blank", "noreferrer");
                 }
@@ -57,7 +190,7 @@ export function buildLivePreview<V extends PluginValue>(plugin: MathLinks, leaf:
             mathLinkWrapper.onauxclick = ((evt: MouseEvent) => {
                 if (evt.button == 1) {
                     if (targetFile) {
-                        plugin.app.workspace.openLinkText(this.outLinkText, sourcePath, true);
+                        plugin.app.workspace.openLinkText(this.outLinkText, this.sourcePath, true);
                     } else {
                         self.open(this.outLinkText, "_blank", "noreferrer");
                     }
@@ -68,143 +201,116 @@ export function buildLivePreview<V extends PluginValue>(plugin: MathLinks, leaf:
         }
     }
 
-    let viewPlugin = ViewPlugin.fromClass(
-        class {
+    const mathLinksViewPlugin = ViewPlugin.fromClass(
+        class implements PluginValue {
             decorations: DecorationSet;
 
             constructor(view: EditorView) {
-                leafView = leaf.view as FileView;
-                this.tryBuildingDecorations(view);
+                this.decorations = this.buildDecorations(view);
+            }
+
+            buildDecorations(view: EditorView): DecorationSet {
+                // Disable in source mode if all the provider are disabled in source mode.
+                if (!view.state.field(editorLivePreviewField) && !plugin.enableInSourceMode()) {
+                    return Decoration.none;
+                }
+
+                const sourcePath = view.state.field(editorInfoField).file?.path ?? '';
+                const isSourceMode = !view.state.field(editorLivePreviewField);
+                const info = view.state.field(mathLinkInfoField);
+
+                const builder = new RangeSetBuilder<Decoration>();
+                const selection = view.state.selection;
+
+                for (const { from, to } of view.visibleRanges) {
+                    info.between(from, to, (start, end, { linkText, mathLink }) => {
+                        // If the inline field is not overlapping with the cursor, we replace it with a widget.
+                        if (!selectionAndRangeOverlap(selection, start, end)) {
+                            builder.add(
+                                start,
+                                end,
+                                Decoration.widget({
+                                    widget: new MathWidget(linkText, mathLink, isSourceMode, sourcePath),
+                                })
+                            );
+                        }
+                    });
+                }
+                return builder.finish();
             }
 
             update(update: ViewUpdate) {
-                this.tryBuildingDecorations(update.view);
-            }
+                // Disable in source mode if all the provider are disabled in source mode.
+                if (!update.state.field(editorLivePreviewField) && !plugin.enableInSourceMode()) {
+                    this.decorations = Decoration.none;
+                }
 
-            tryBuildingDecorations(view: EditorView) {
-                this.decorations = Decoration.none;
-
-                let editorView = leaf.getViewState();
-
-                if (leaf.view instanceof MarkdownView && leaf.view.file instanceof TFile && isExcluded(plugin, leaf.view.file)) {
-                    let curView = leaf.view.editor.cm;
-                    if (curView == view && editorView.state.mode == "source" && (!editorView.state.source || plugin.enableInSourceMode())) {
-                        this.decorations = this.buildDecorations(view);
-                    } else {
-                        this.decorations = Decoration.none;
-                    }
-                } else if (leafView.canvas) {
-                    for (let node of leafView.canvas.selection.values()) {
-                        if (isExcluded(plugin, node.file)) {
-                            this.decorations = this.buildDecorations(view);
-                        }
-                    }
-
-                    plugin.app.workspace.iterateRootLeaves((otherLeaf: WorkspaceLeaf) => {
-                        if (otherLeaf.view instanceof MarkdownView) {
-                            let otherView = otherLeaf.view.editor.cm;
-                            if (otherView == view) {
-                                this.decorations = Decoration.none;
-                            }
-                        }
-                    });
+                if (update.transactions.some(tr => hasEffect(tr, forceUpdateEffect))) {
+                    this.decorations = this.buildDecorations(update.view);
+                } else if (update.docChanged) {
+                    this.decorations = this.decorations.map(update.changes);
+                    this.updateDecorations(update.view);
+                } else if (update.selectionSet) {
+                    this.updateDecorations(update.view);
+                } else if (update.viewportChanged) {
+                    this.decorations = this.buildDecorations(update.view);
                 }
             }
 
-            buildDecorations(view: EditorView) {
-                let builder = new RangeSetBuilder<Decoration>();
+            updateDecorations(view: EditorView) {
+                const file = view.state.field(editorInfoField).file;
+                const sourcePath = file?.path ?? '';
                 const isSourceMode = !view.state.field(editorLivePreviewField);
+                const info = view.state.field(mathLinkInfoField);
+                const selection = view.state.selection;
 
-                for (let { from, to } of view.visibleRanges) {
-                    let start = -1, end = -1, outLinkText = "", outLinkMathLink = "";
-
-                    syntaxTree(view.state).iterate({
-                        from,
-                        to,
-                        enter(node) {
-                            let name = node.type.name;
-
-                            // Start
-                            if (name.contains("formatting-link_formatting-link-start")) {
-                                if (view.state.sliceDoc(node.from, node.to) == "[[" && node.node.nextSibling) {
-                                    start = node.node.nextSibling.from;
-                                    // start = node.from;
-                                } else {
-                                    return;
-                                }
-                            }
-
-                            // Start (check that it is not end)
-                            else if (name.contains("formatting_formatting-link_link")) {
-                                if (start == -1) {
-                                    start = node.from;
-                                }
-                            }
-
-                            // Alias: File name
-                            else if (name.contains("has-alias")) {
-                                outLinkText += view.state.doc.sliceString(node.from, node.to);
-                                if (leafView.file && outLinkMathLink == outLinkText.replace(/\.md/, "")) {
-                                    outLinkMathLink = getMathLink(plugin, outLinkText, leafView.file.path, isSourceMode);
-                                }
-                            }
-
-                            // Alias: File name (with decoding)
-                            else if (/string_url$/.test(name) && !name.contains("format")) {
-                                outLinkText += decodeURI(view.state.doc.sliceString(node.from, node.to));
-                                if (leafView.file && outLinkMathLink == outLinkText.replace(/\.md/, "")) {
-                                    outLinkMathLink = getMathLink(plugin, outLinkText, leafView.file.path, isSourceMode);
-                                }
-                            }
-
-                            // No alias
-                            else if (leafView.file && name.contains("hmd-internal-link") && !name.contains("alias")) {
-                                outLinkText += view.state.doc.sliceString(node.from, node.to);
-                                outLinkMathLink = getMathLink(plugin, outLinkText, leafView.file.path, isSourceMode);
-                            }
-
-                            // End
-                            else if (name.contains("formatting-link-end") || name.contains("formatting-link-string")) {
-                                if (!name.contains("end") && end == -1) {
-                                    end = -2;
-                                } else if (node.node.prevSibling && (!isSourceMode || view.state.sliceDoc(node.from, node.to) == "]]")) {
-                                    // end = node.to;
-                                    end = node.node.prevSibling.to;
-
-                                    let cursorRange = view.state.selection.main;
-                                    if (start > cursorRange.to || end < cursorRange.from) {
-                                        if (outLinkText && outLinkMathLink) {
-                                            builder.add(
-                                                start,
-                                                end,
-                                                Decoration.widget({
-                                                    widget: new MathWidget(outLinkText, outLinkMathLink.replace(/\\\$/, "$"), isSourceMode),
-                                                })
-                                            );
-                                        }
-                                    }
-                                    start = -1;
-                                    end = -1;
-                                    outLinkText = "";
-                                    outLinkMathLink = "";
-                                }
-                            }
-
-                            // Alias: MathLink
-                            else if (!name.contains("pipe") && ((name.contains("hmd-internal-link") && name.contains("alias")) || (name.contains("hmd-escape") && name.contains("link")) || /^link/.test(name))) {
-                                outLinkMathLink += view.state.doc.sliceString(node.from, node.to);
-                                if (leafView.file && outLinkMathLink == outLinkText.replace(/\.md/, "")) {
-                                    outLinkMathLink = getMathLink(plugin, outLinkText, leafView.file.path, isSourceMode);
-                                }
-                            }
+                for (const { from, to } of view.visibleRanges) {
+                    info.between(from, to, (start, end, value) => {
+                        const overlap = selectionAndRangeOverlap(selection, start, end);
+                        if (overlap) {
+                            this.removeDeco(start, end);
+                            return;
+                        } else {
+                            this.addDeco(start, end, value, isSourceMode, sourcePath);
                         }
                     });
                 }
-
-                return builder.finish();
             }
-        }, { decorations: v => v.decorations }
+
+            removeDeco(start: number, end: number) {
+                this.decorations.between(start, end, (from, to) => {
+                    this.decorations = this.decorations.update({
+                        filterFrom: from,
+                        filterTo: to,
+                        filter: () => false,
+                    });
+                });
+            }
+
+            addDeco(start: number, end: number, value: MathLinkInfo, isSourceMode: boolean, sourcePath: string) {
+                let exists = false;
+                this.decorations.between(start, end, () => {
+                    exists = true;
+                });
+                if (!exists) {
+                    this.decorations = this.decorations.update({
+                        add: [
+                            {
+                                from: start,
+                                to: end,
+                                value: Decoration.widget({
+                                    widget: new MathWidget(value.linkText, value.mathLink, isSourceMode, sourcePath),
+                                }),
+                            },
+                        ],
+                    });
+                }
+            }
+        },
+        {
+            decorations: instance => instance.decorations,
+        }
     );
 
-    return new Promise<ViewPlugin<V>>((resolve) => { resolve(viewPlugin) });
+    return [mathLinkInfoField, mathLinksViewPlugin];
 }

--- a/src/links/preview.ts
+++ b/src/links/preview.ts
@@ -1,3 +1,32 @@
+/**
+ * Inspired by & adapted from Dataview's inline fields rendering feature:
+ * https://github.com/blacksmithgu/obsidian-dataview/blob/b00beb7596f9926ca9579c6f319341ceae4f5b5e/src/ui/views/inline-field-live-preview.ts
+ * 
+ * The original work is licensed under the MIT License:
+ * 
+ * MIT License
+ * 
+ * Copyright (c) 2021 Michael Brenan
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 import { Keymap, editorInfoField, editorLivePreviewField, getLinkpath } from "obsidian";
 import { Transaction, EditorState, RangeSet, RangeSetBuilder, RangeValue, StateEffect, StateEffectType, StateField, EditorSelection, Extension } from "@codemirror/state";
 import {

--- a/src/links/preview.ts
+++ b/src/links/preview.ts
@@ -124,9 +124,6 @@ export function buildLivePreview<V extends PluginValue>(plugin: MathLinks, leaf:
                         enter(node) {
                             let name = node.type.name;
 
-                            console.log(
-                                `"${view.state.sliceDoc(node.from, node.to)}" (${node.name}): ${node.from}-${node.to}`,
-                            );
                             // Start
                             if (name.contains("formatting-link_formatting-link-start")) {
                                 if (view.state.sliceDoc(node.from, node.to) == "[[" && node.node.nextSibling) {

--- a/src/links/reading.ts
+++ b/src/links/reading.ts
@@ -23,22 +23,15 @@ export class MathLinksRenderChild extends MarkdownRenderChild {
     onload(): void {
         this.update();
 
-        // 1. when user updates the YAML frontmatter
-        this.plugin.registerEvent(this.plugin.app.metadataCache.on("changed", (changedFile) => {
+        // 1. when an API user updates its metadata
+        this.registerEvent(this.plugin.app.metadataCache.on("mathlinks:update", (changedFile) => {
             if (!this.targetFile || this.targetFile == changedFile) {
                 this.update();
             }
         }));
 
-        // 2. when an API user updates its metadata
-        this.plugin.registerEvent(this.plugin.app.metadataCache.on("mathlinks:update", (changedFile) => {
-            if (!this.targetFile || this.targetFile == changedFile) {
-                this.update();
-            }
-        }));
-
-        // 3. when an API account is deleted
-        this.plugin.registerEvent(this.plugin.app.metadataCache.on("mathlinks:update-all", () => {
+        // 2. when an API account is deleted
+        this.registerEvent(this.plugin.app.metadataCache.on("mathlinks:update-all", () => {
             this.update();
         }));
     }
@@ -57,7 +50,7 @@ export class MathLinksRenderChild extends MarkdownRenderChild {
         return getter;
     }
 
-    async update(): Promise<void> {
+    update(): void {
         const mathLink = this.getMathLink();
 
         if (mathLink) {

--- a/src/links/reading.ts
+++ b/src/links/reading.ts
@@ -31,14 +31,14 @@ export class MathLinksRenderChild extends MarkdownRenderChild {
         }));
 
         // 2. when an API user updates its metadata
-        this.plugin.registerEvent(this.plugin.app.metadataCache.on("mathlinks:updated", (apiAccount, changedFile) => {
+        this.plugin.registerEvent(this.plugin.app.metadataCache.on("mathlinks:update", (changedFile) => {
             if (!this.targetFile || this.targetFile == changedFile) {
                 this.update();
             }
         }));
 
         // 3. when an API account is deleted
-        this.plugin.registerEvent(this.plugin.app.metadataCache.on("mathlinks:account-deleted", (apiAccount) => {
+        this.plugin.registerEvent(this.plugin.app.metadataCache.on("mathlinks:update-all", () => {
             this.update();
         }));
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,12 +11,15 @@ export default class MathLinks extends Plugin {
     settings: MathLinksSettings;
     apiAccounts: MathLinksAPIAccount[];
     providers: { provider: Provider, sortOrder: number }[] = [];
+    nativeProvider: NativeProvider;
 
     async onload() {
         await this.loadSettings();
         await loadMathJax();
 
-        this.registerProvider(new NativeProvider(this), Infinity);
+        this.nativeProvider = new NativeProvider(this);
+        this.addChild(this.nativeProvider);
+        this.registerProvider(this.nativeProvider, Infinity);
 
         // Markdown Post Processor for reading view
         this.registerMarkdownPostProcessor((element, context) => {
@@ -83,5 +86,9 @@ export default class MathLinks extends Plugin {
         this.providers
             .sort((p1, p2) => p1.sortOrder - p2.sortOrder)
             .forEach(({ provider }) => callback(provider));
+    }
+
+    enableInSourceMode(): boolean {
+        return this.providers.some(({provider}) => provider.enableInSourceMode);
     }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import { createEditorExtensions } from './links/preview';
 import { Plugin, loadMathJax } from "obsidian";
 import { MathLinksSettings, DEFAULT_SETTINGS } from "./settings/settings";
 import { MathLinksSettingTab } from "./settings/tab"
-import { MathLinksAPIAccount } from "./api/api";
+import { MathLinksAPIAccount } from "./api/deprecated";
 import { DeprecatedAPIProvider, NativeProvider, Provider } from "./api/provider";
 import { generateMathLinks } from "./links/reading";
 import { isExcluded } from "./utils";

--- a/src/main.ts
+++ b/src/main.ts
@@ -59,7 +59,9 @@ export default class MathLinks extends Plugin {
         account = new MathLinksAPIAccount(this, userPlugin.manifest, DEFAULT_SETTINGS.blockPrefix, () => null);
         this.apiAccounts.push(account);
 
-        this.registerProvider(new DeprecatedAPIProvider(account));
+        const provider = new DeprecatedAPIProvider(account);
+        userPlugin.addChild(provider);
+        this.registerProvider(provider);
 
         return account;
     }

--- a/src/settings/modals.ts
+++ b/src/settings/modals.ts
@@ -1,5 +1,5 @@
 import { Setting, Modal, Notice, TFile, TAbstractFile, TFolder, FuzzySuggestModal, App } from "obsidian";
-import { TextComponent, ButtonComponent, ExtraButtonComponent } from "obsidian";
+import { TextComponent, ExtraButtonComponent } from "obsidian";
 import { Template } from "./settings";
 import { isEqualToOrChildOf } from "../utils";
 import MathLinks from "../main"

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -1,11 +1,8 @@
-import { TAbstractFile } from "obsidian";
-
 export interface MathLinksSettings {
     templates: Template[];
     excludedPaths: string[];
     blockPrefix: string;
     enableFileNameBlockLinks: boolean;
-    enableAPI: boolean;
 }
 
 export type Template = {
@@ -20,6 +17,5 @@ export const DEFAULT_SETTINGS: MathLinksSettings = {
     templates: [],
     excludedPaths: [],
     blockPrefix: "^",
-    enableFileNameBlockLinks: true,
-    enableAPI: true,
+    enableFileNameBlockLinks: true
 }

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -3,6 +3,7 @@ export interface MathLinksSettings {
     excludedPaths: string[];
     blockPrefix: string;
     enableFileNameBlockLinks: boolean;
+    enableInSourceMode: boolean;
 }
 
 export type Template = {
@@ -17,5 +18,6 @@ export const DEFAULT_SETTINGS: MathLinksSettings = {
     templates: [],
     excludedPaths: [],
     blockPrefix: "^",
-    enableFileNameBlockLinks: true
+    enableFileNameBlockLinks: true,
+    enableInSourceMode: false,
 }

--- a/src/settings/tab.ts
+++ b/src/settings/tab.ts
@@ -91,10 +91,10 @@ export class MathLinksSettingTab extends PluginSettingTab {
         // Source mode
         new Setting(containerEl)
             .setName("Enable in Source mode")
-            .setName("Currently, only wikilinks are supported in Source mode.")
+            .setDesc("Currently, only wikilinks are supported in Source mode.")
             .addToggle((toggle: ToggleComponent) => {
                 toggle.setValue(this.plugin.nativeProvider.enableInSourceMode)
-                    .onChange(async (value: boolean) => {
+                    .onChange((value: boolean) => {
                         this.plugin.nativeProvider.enableInSourceMode = value;
                     });
             });

--- a/src/settings/tab.ts
+++ b/src/settings/tab.ts
@@ -1,5 +1,5 @@
-import { Setting, PluginSettingTab, Notice, App } from "obsidian";
-import { TextComponent, DropdownComponent, ToggleComponent, ButtonComponent } from "obsidian"
+import { Setting, PluginSettingTab, App } from "obsidian";
+import { TextComponent, ToggleComponent, ButtonComponent } from "obsidian"
 import { TemplatesModal, ExcludeModal } from "./modals"
 import MathLinks from "../main"
 
@@ -86,30 +86,6 @@ export class MathLinksSettingTab extends PluginSettingTab {
                         });
                     });
                 toggle.setTooltip("Disable to ignore note name.");
-            });
-
-        // Enable API
-        new Setting(containerEl)
-            .setName("Enable MathLinks API")
-            .setDesc(
-                createFragment((e) => {
-                    let accounts = this.plugin.apiAccounts;
-                    e.createSpan({ text: "Allow other community plugins to use MathLinks." });
-                    if (accounts.length) {
-                        let list = e.createEl("ul");
-                        for (let account of accounts) {
-                            list.createEl("li", { text: account.manifest.name });
-                        }
-                    }
-                })
-            ).addToggle((toggle: ToggleComponent) => {
-                toggle.setValue(this.plugin.settings.enableAPI)
-                    .onChange(async (value: boolean) => {
-                        this.plugin.settings.enableAPI = value;
-                        await this.plugin.saveSettings().then(() => {
-                            this.display();
-                        });
-                    })
             });
     }
 }

--- a/src/settings/tab.ts
+++ b/src/settings/tab.ts
@@ -87,5 +87,15 @@ export class MathLinksSettingTab extends PluginSettingTab {
                     });
                 toggle.setTooltip("Disable to ignore note name.");
             });
+
+        // Source mode
+        new Setting(containerEl)
+            .setName("Enable in source mode")
+            .addToggle((toggle: ToggleComponent) => {
+                toggle.setValue(this.plugin.nativeProvider.enableInSourceMode)
+                    .onChange(async (value: boolean) => {
+                        this.plugin.nativeProvider.enableInSourceMode = value;
+                    });
+            });
     }
 }

--- a/src/settings/tab.ts
+++ b/src/settings/tab.ts
@@ -90,7 +90,8 @@ export class MathLinksSettingTab extends PluginSettingTab {
 
         // Source mode
         new Setting(containerEl)
-            .setName("Enable in source mode")
+            .setName("Enable in Source mode")
+            .setName("Currently, only wikilinks are supported in Source mode.")
             .addToggle((toggle: ToggleComponent) => {
                 toggle.setValue(this.plugin.nativeProvider.enableInSourceMode)
                     .onChange(async (value: boolean) => {

--- a/src/type.d.ts
+++ b/src/type.d.ts
@@ -33,13 +33,29 @@ declare module "obsidian" {
     interface MetadataCache {
         /** Custom events */
 
-        // triggered when an API user updates its MathLinks metadata
+        on(
+            name: "mathlinks:update",
+            callback: (file: TFile) => any
+        ): EventRef;
+
+        on(
+            name: "mathlinks:update-all",
+            callback: () => any
+        ): EventRef;
+
+        /** 
+         * triggered when an API user updates its MathLinks metadata 
+         * @deprecated
+         */
         on(
             name: "mathlinks:updated",
             callback: (apiAccount: MathLinksAPIAccount, file: TFile) => any
         ): EventRef;
 
-        // triggered when an API account is deleted
+        /** 
+         * triggered when an API account is deleted
+         * @deprecated
+         */
         on(
             name: "mathlinks:account-deleted",
             callback: (apiAccount: MathLinksAPIAccount) => any

--- a/src/type.d.ts
+++ b/src/type.d.ts
@@ -1,13 +1,6 @@
 import { EditorView } from "@codemirror/view";
-import { MathLinksAPIAccount } from "./api/api";
 import MathLinks from "./main";
 
-// Reference: 
-// https://gist.github.com/aidenlx/6067c943fbec8ead230f2b163bfd3bc8#file-api-d-ts-L25
-// https://github.com/blacksmithgu/obsidian-dataview/blob/master/src/typings/obsidian-ex.d.ts
-// https://github.com/eth-p/obsidian-callout-manager/blob/fb8699a9f5e3bfaa0bcedd02411ea9748004e0fb/api/index.ts#L9
-// https://github.com/mdelobelle/obsidian_supercharged_links/blob/master/types.d.ts
-// https://github.com/aidenlx/folder-note-core/blob/master/src/typings/obsidian-ex.d.ts
 declare module "obsidian" {
     interface App {
         plugins: {
@@ -41,41 +34,6 @@ declare module "obsidian" {
         on(
             name: "mathlinks:update-all",
             callback: () => any
-        ): EventRef;
-
-        /** 
-         * triggered when an API user updates its MathLinks metadata 
-         * @deprecated
-         */
-        on(
-            name: "mathlinks:updated",
-            callback: (apiAccount: MathLinksAPIAccount, file: TFile) => any
-        ): EventRef;
-
-        /** 
-         * triggered when an API account is deleted
-         * @deprecated
-         */
-        on(
-            name: "mathlinks:account-deleted",
-            callback: (apiAccount: MathLinksAPIAccount) => any
-        ): EventRef;
-
-        /** Dataview Events */
-        on(
-            name: "dataview:index-ready",
-            callback: () => any,
-            ctx?: any
-        ): EventRef;
-        on(
-            name: "dataview:metadata-change",
-            callback: (
-                ...args:
-                    | [op: "rename", file: TAbstractFile, oldPath: string]
-                    | [op: "delete", file: TFile]
-                    | [op: "update", file: TFile]
-            ) => any,
-            ctx?: any
         ): EventRef;
     }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,6 @@
-import { TAbstractFile, TFolder } from "obsidian";
+import { App, MarkdownView, TAbstractFile, TFile, TFolder, WorkspaceLeaf } from "obsidian";
 import MathLinks from "./main";
+import { forceUpdateEffect } from "./links/preview";
 
 // Check if path is excluded
 export function isExcluded(plugin: MathLinks, file: TAbstractFile): boolean {
@@ -39,4 +40,19 @@ export function isEqualToOrChildOf(file1: TAbstractFile, file2: TAbstractFile): 
             ancestor = ancestor.parent;
         }
     }
+}
+
+// eventName: see src/type.d.ts
+export function informChange(app: App, eventName: string, ...callbackArgs: [file?: TFile]) {
+    // trigger an event informing this update
+    app.metadataCache.trigger(eventName, ...callbackArgs);
+
+    // refresh mathLinks display based on the new metadata
+    app.workspace.iterateRootLeaves((leaf: WorkspaceLeaf) => {
+        if (leaf.view instanceof MarkdownView && leaf.view.getMode() == 'source') {
+            leaf.view.editor.cm?.dispatch({
+                effects: forceUpdateEffect.of(null)
+            });
+        }
+    });
 }

--- a/test_vault/.obsidian/community-plugins.json
+++ b/test_vault/.obsidian/community-plugins.json
@@ -1,6 +1,7 @@
 [
-  "mathlinks",
   "dataview",
-  "supercharged-links-obsidian",
-  "obsidian-style-settings"
+  "obsidian-style-settings",
+  "mathlinks",
+  "math-booster",
+  "supercharged-links-obsidian"
 ]

--- a/test_vault/.obsidian/plugins/dataview/manifest.json
+++ b/test_vault/.obsidian/plugins/dataview/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "dataview",
   "name": "Dataview",
-  "version": "0.5.56",
+  "version": "0.5.64",
   "minAppVersion": "0.13.11",
   "description": "Complex data views for the data-obsessed.",
   "author": "Michael Brenan <blacksmithgu@gmail.com>",

--- a/test_vault/.obsidian/plugins/dataview/styles.css
+++ b/test_vault/.obsidian/plugins/dataview/styles.css
@@ -23,7 +23,7 @@
 }
 
 .table-view-table > tbody > tr:hover {
-    background-color: var(--text-selection) !important;
+    background-color: var(--table-row-background-hover);
 }
 
 .table-view-table > thead > tr > th {

--- a/test_vault/.obsidian/plugins/math-booster/data.json
+++ b/test_vault/.obsidian/plugins/math-booster/data.json
@@ -1,9 +1,14 @@
 {
-  "version": "0.6.11",
+  "version": "1.0.4",
   "settings": {
     "/": {
       "profile": "English",
       "titleSuffix": ".",
+      "inferNumberPrefix": true,
+      "inferNumberPrefixFromProperty": "",
+      "inferNumberPrefixParseSep": "-.",
+      "inferNumberPrefixPrintSep": ".",
+      "inferNumberPrefixUseFirstN": 1,
       "numberPrefix": "",
       "numberSuffix": "",
       "numberInit": 1,
@@ -11,6 +16,11 @@
       "numberDefault": "auto",
       "refFormat": "[title] ([type] [number]) if title exists, [type] [number] otherwise",
       "noteMathLinkFormat": "[type] [number] ([title])",
+      "inferEqNumberPrefix": true,
+      "inferEqNumberPrefixFromProperty": "",
+      "inferEqNumberPrefixParseSep": "-.",
+      "inferEqNumberPrefixPrintSep": ".",
+      "inferEqNumberPrefixUseFirstN": 1,
       "eqNumberPrefix": "",
       "eqNumberSuffix": "",
       "eqNumberInit": 1,
@@ -19,8 +29,8 @@
       "eqRefSuffix": "",
       "labelPrefix": "",
       "lineByLine": true,
-      "mathCalloutStyle": "Framed",
-      "mathCalloutFontInherit": false,
+      "theoremCalloutStyle": "Framed",
+      "theoremCalloutFontInherit": false,
       "beginProof": "\\begin{proof}",
       "endProof": "\\end{proof}",
       "insertSpace": true
@@ -96,12 +106,18 @@
     "triggerTheoremSuggest": "\\tref",
     "triggerEquationSuggest": "\\eqref",
     "renderMathInSuggestion": true,
+    "suggestNumber": 20,
     "searchMethod": "Fuzzy",
     "upWeightRecent": 0.1,
     "searchOnlyRecent": false,
     "modifierToJump": "Mod",
+    "modifierToNoteLink": "Shift",
+    "showModifierInstruction": true,
     "suggestLeafOption": "Split right",
-    "backlinkLeafOption": "Split right"
+    "backlinkLeafOption": "Split right",
+    "projectInfix": " > ",
+    "projectSep": "/"
   },
-  "excludedFiles": []
+  "excludedFiles": [],
+  "dumpedProjects": []
 }

--- a/test_vault/.obsidian/plugins/math-booster/manifest.json
+++ b/test_vault/.obsidian/plugins/math-booster/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "math-booster",
 	"name": "Math Booster",
-	"version": "0.6.11",
+	"version": "1.0.4",
 	"minAppVersion": "1.3.5",
 	"description": "Turn your Obsidian into LaTeX on steroids. Dynamically numbered theorem environments & equations, theorems/equations live suggestion, showing backlinks to theorems/equations and live-rendering equations inside callouts & quotes.",
 	"author": "Ryota Ushio",

--- a/test_vault/.obsidian/plugins/math-booster/styles.css
+++ b/test_vault/.obsidian/plugins/math-booster/styles.css
@@ -43,7 +43,7 @@
     width: 200px;
 }
 
-.math-booster-profile-button-container {
+.math-booster-button-container {
     display: flex;
     flex-direction: row;
     justify-content: flex-end;
@@ -77,8 +77,9 @@
                 
 /* Unlike in callouts, Obsidian natively renders MathJax in blockquotes. But it is rather buggy 
 (see https://forum.obsidian.md/t/live-preview-support-math-block-in-quotes/32564/2), 
-so we need to replace it with this plugin's editor extension. */
-.cm-line:has( .math.math-block.cm-embed-block > mjx-container.MathJax:not(.math-booster-preview) > mjx-math[display="true"]) {
+so we need to replace it with this plugin's editor extension. 
+*/
+.HyperMD-quote.cm-line .math.math-block.cm-embed-block:has(> mjx-container.MathJax[display="true"]:not(.math-booster-preview)) {
     display: none;
 }
 
@@ -109,54 +110,34 @@ so we need to replace it with this plugin's editor extension. */
     width: 300px;
 }
 
-.theorem-callout-plain.theorem-callout {
-    --callout-color: var(--text-normal);
-    font-family: CMU Serif;
-    background-color: rgb(0, 0, 0, 0);
-    padding-left: 0;
-    padding-right: 0;
-    border: none;
-    box-shadow: none;
+
+/* Taken from the Latex Suite plugin (https://github.com/artisticat1/obsidian-latex-suite/blob/a5914c70c16d5763a182ec51d9716110b40965cf/styles.css) */
+.math-booster-dependency-validation {
+    color: white;
+    display: inline-block;
+    border-radius: 1em;
+    margin-right: var(--size-3);
+    cursor: default;
+    pointer-events: none;
 }
 
-.theorem-callout-plain.theorem-callout .callout-icon {
-    display: none;
+.math-booster-dependency-validation svg {
+    width: 16px !important;
+    height: 16px !important;
 }
 
-.theorem-callout-plain.theorem-callout .callout-title-inner {
-    font-style: bold;
+.math-booster-dependency-validation.valid {
+    background-color: #7dc535;
+    visibility: visible;
 }
 
-.theorem-callout-plain .theorem-callout-subtitle {
-    font-weight: 400;
+.theme-dark .math-booster-dependency-validation.valid {
+    background-color: #588b24;
 }
 
-.theorem-callout-plain.theorem-callout-en .callout-content {
-    font-style: italic;
-}
-
-.theorem-callout-framed.theorem-callout {
-    --callout-color: var(--text-normal);
-    font-family: Times;
-    background-color: rgb(0, 0, 0, 0);
-    border: solid;
-    border-radius: 6px;
-}
-
-.theorem-callout-framed.theorem-callout .callout-icon {
-    display: none;
-}
-
-.theorem-callout-framed.theorem-callout .callout-title-inner {
-    font-style: bold;
-}
-
-.theorem-callout-framed .theorem-callout-subtitle {
-    font-weight: 400;
-}
-
-.theorem-callout-framed.theorem-callout-en .callout-content {
-    font-style: italic;
+.math-booster-dependency-validation.invalid {
+    background-color: #ea5555;
+    visibility: visible;
 }
 
 .theorem-callout-vivid.theorem-callout {
@@ -195,6 +176,56 @@ so we need to replace it with this plugin's editor extension. */
     padding: 1px 20px 2px 20px;
 }
 
+.theorem-callout-framed.theorem-callout {
+    --callout-color: var(--text-normal);
+    font-family: Times;
+    background-color: rgb(0, 0, 0, 0);
+    border: solid;
+    border-radius: 6px;
+}
+
+.theorem-callout-framed.theorem-callout .callout-icon {
+    display: none;
+}
+
+.theorem-callout-framed.theorem-callout .callout-title-inner {
+    font-style: bold;
+}
+
+.theorem-callout-framed .theorem-callout-subtitle {
+    font-weight: 400;
+}
+
+.theorem-callout-framed.theorem-callout-en .callout-content {
+    font-style: italic;
+}
+
+.theorem-callout-plain.theorem-callout {
+    --callout-color: var(--text-normal);
+    font-family: CMU Serif;
+    background-color: rgb(0, 0, 0, 0);
+    padding-left: 0;
+    padding-right: 0;
+    border: none;
+    box-shadow: none;
+}
+
+.theorem-callout-plain.theorem-callout .callout-icon {
+    display: none;
+}
+
+.theorem-callout-plain.theorem-callout .callout-title-inner {
+    font-style: bold;
+}
+
+.theorem-callout-plain .theorem-callout-subtitle {
+    font-weight: 400;
+}
+
+.theorem-callout-plain.theorem-callout-en .callout-content {
+    font-style: italic;
+}
+
 .theorem-callout-mathwiki.theorem-callout {
     --callout-color: 248, 248, 255;
     font-family: CMU Serif;
@@ -202,6 +233,10 @@ so we need to replace it with this plugin's editor extension. */
 
 .theorem-callout-mathwiki.theorem-callout .callout-title-inner {
     padding-left: 5px;
+}
+
+.theorem-callout-mathwiki .theorem-callout-subtitle {
+    font-weight: 400;
 }
 
 .theorem-callout-mathwiki.theorem-callout-en .callout-content {

--- a/test_vault/.obsidian/plugins/obsidian-style-settings/manifest.json
+++ b/test_vault/.obsidian/plugins/obsidian-style-settings/manifest.json
@@ -1,10 +1,10 @@
 {
-  "id": "obsidian-style-settings",
-  "name": "Style Settings",
-  "version": "1.0.6",
-  "minAppVersion": "0.11.5",
-  "description": "Offers controls for adjusting theme, plugin, and snippet CSS variables.",
-  "author": "mgmeyers",
-  "authorUrl": "https://github.com/mgmeyers/obsidian-style-settings",
-  "isDesktopOnly": false
+	"id": "obsidian-style-settings",
+	"name": "Style Settings",
+	"version": "1.0.7",
+	"minAppVersion": "0.11.5",
+	"description": "Offers controls for adjusting theme, plugin, and snippet CSS variables.",
+	"author": "mgmeyers",
+	"authorUrl": "https://github.com/mgmeyers/obsidian-style-settings",
+	"isDesktopOnly": false
 }

--- a/test_vault/.obsidian/plugins/supercharged-links-obsidian/manifest.json
+++ b/test_vault/.obsidian/plugins/supercharged-links-obsidian/manifest.json
@@ -1,8 +1,8 @@
 {
 	"id": "supercharged-links-obsidian",
 	"name": "Supercharged Links",
-	"version": "0.9.0",
-	"minAppVersion": "0.16.0",
+	"version": "0.11.1",
+	"minAppVersion": "1.4.0",
 	"description": "Add properties and menu options to links and style them!",
 	"author": "mdelobelle & Emile",
 	"authorUrl": "https://github.com/mdelobelle/mdelobelle/tree/main",

--- a/test_vault/Canvas.canvas
+++ b/test_vault/Canvas.canvas
@@ -4,10 +4,12 @@
 		{"type":"file","file":"Tests/Formats.md","id":"764b6fe364dd2a1b","x":800,"y":-300,"width":260,"height":460},
 		{"type":"file","file":"Tests/Blocks and Headings.md","id":"b20864e3e2330c7c","x":1120,"y":-300,"width":260,"height":460},
 		{"type":"file","file":"Tests/Markdown Links.md","id":"7ce6fd7f2c2a28e7","x":160,"y":-300,"width":260,"height":186},
-		{"type":"file","file":"Tests/Wikilinks.md","id":"72af7f7e6ad41a84","x":-160,"y":-300,"width":260,"height":118},
+		{"type":"file","file":"Tests/Wikilinks.md","id":"72af7f7e6ad41a84","x":-160,"y":-300,"width":260,"height":186},
 		{"type":"file","file":"Tests/Callouts.md","id":"ce67ad19d3800d0e","x":160,"y":-70,"width":260,"height":300},
+		{"type":"file","file":"Tests/Excluded.md","id":"dbcb2b838f398b22","x":160,"y":280,"width":260,"height":100},
+		{"id":"e258d18df2ee88f8","x":-160,"y":160,"width":260,"height":120,"type":"file","file":"Tests/URL.md"},
 		{"type":"file","file":"Tests/API Exposure.md","id":"83d3a4f8973194dd","x":-160,"y":-70,"width":260,"height":190},
-		{"type":"file","file":"Tests/Excluded.md","id":"dbcb2b838f398b22","x":160,"y":280,"width":260,"height":100}
+		{"id":"8cf24ea72c7f83fc","x":-160,"y":329,"width":260,"height":91,"type":"file","file":"Tests/Templates.md"}
 	],
 	"edges":[]
 }


### PR DESCRIPTION
I've been feeling the current implementation of the API is not fully flexible. So I've remade it with the most flexibility imaginable (but fortunately, I was able to keep the backward compatibility).

Now, a user plugin does not register a metadata (`mathLink`, `mathLink-blocks`) for each file. Instead, It implements a class that dynamically determines `mathLink` from a pre-processed information (e.g. the target & source `TFile`) about the given link. For example, this would be beneficial for a plugin that displays the value of a specified property as mathLink.

(An interesting point is that, now MathLinks itself can be thought as an API user.)

Also, I wrote a simple sample plugin for demonstrating the new API (and realized again how powerful MathLinks is... I must say this plugin is super great, totally underrated...).

https://github.com/RyotaUshio/obsidian-mathlinks-api-sample-plugin

@zhaoshenzhai 
I'm not happy about the name 'Provider'. So let me know if you have some better idea about it, as well as the overall API implementation.

Anyway, I will do some more testing with Math Booster and the sample plugin before merging. 