### PR TITLE
Fixed the bug where a link is not added to the state field when the cursor is overlapping with it

### DIFF
--- a/src/links/preview.ts
+++ b/src/links/preview.ts
@@ -90,7 +90,7 @@ export const createEditorExtensions = (plugin: MathLinks): Extension[] => {
                             start = node.node.nextSibling.from;
                         } else {
                             return;
-                        }    
+                        }
                     } else {
                         start = node.from;
                     }
@@ -140,16 +140,14 @@ export const createEditorExtensions = (plugin: MathLinks): Extension[] => {
                             end = node.to;
                         }
 
-                        let cursorRange = state.selection.main;
-                        if (start > cursorRange.to || end < cursorRange.from) {
-                            if (outLinkText && outLinkMathLink) {
-                                builder.add(
-                                    start,
-                                    end,
-                                    new MathLinkInfo(outLinkText, outLinkMathLink.replace(/\\\$/, "$")),
-                                );
-                            }
+                        if (outLinkText && outLinkMathLink) {
+                            builder.add(
+                                start,
+                                end,
+                                new MathLinkInfo(outLinkText, outLinkMathLink.replace(/\\\$/, "$")),
+                            );
                         }
+
                         start = -1;
                         end = -1;
                         outLinkText = "";


### PR DESCRIPTION
## Steps to reproduce

1. Turn off MathLinks
2. In Live preview, place the cursor on a link and turn on MathLinks
3. The link that the cursor was put on is not rendered until the next document change
