### PR TITLE
Bugfix & improvement for the API update() function

### DIFF
--- a/src/api/deprecated.ts
+++ b/src/api/deprecated.ts
@@ -4,7 +4,6 @@
 
 import { BlockSubpathResult, HeadingSubpathResult, PluginManifest, TFile } from 'obsidian';
 import MathLinks from '../main';
-import { informChange } from 'src/utils';
 
 export interface MathLinksMetadata {
     "mathLink"?: string;
@@ -38,7 +37,7 @@ export class MathLinksAPIAccount {
     update(file: TFile, newMetadata: MathLinksMetadata): void {
         if (file.extension == "md") {
             this.metadataSet.set(file, Object.assign({}, this.metadataSet.get(file), newMetadata));
-            informChange(this.plugin.app, "mathlinks:update", file);
+            this.plugin.update(file);
         } else {
             throw Error(`MathLinks API: ${this.manifest.name} passed a non-markdown file ${file.path} to update().`);
         }
@@ -70,6 +69,6 @@ export class MathLinksAPIAccount {
         } else {
             throw Error(`MathLinks API: ${this.manifest.name} attempted to delete the MathLinks metadata of ${file.path}, but it does not exist.`);
         }
-        informChange(this.plugin.app, "mathlinks:update", file);
+        this.plugin.update(file);
     }
 }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -5,7 +5,6 @@ import { TFile, type App, type Plugin } from "obsidian";
 import { MathLinksAPIAccount } from "./deprecated";
 import { Provider } from "./provider";
 import MathLinks from "../main";
-import { informChange } from "../utils";
 
 
 export function addProvider<CustomProvider extends Provider>(app: App, providerFactory: (mathLinks: MathLinks) => CustomProvider): CustomProvider {
@@ -26,11 +25,9 @@ export function isPluginEnabled(app: App) {
  * Otherwise, MathLinks will update all notes currently open.
  */
 export function update(app: App, file?: TFile) {
-    if (file) {
-        informChange(app, "mathlinks:update", file);
-    } else {
-        informChange(app, "mathlinks:update-all");
-    }
+    if (!isPluginEnabled(app)) throw Error("MathLinks API: MathLinks is not enabled.");
+    const mathlinks = app.plugins.plugins.mathlinks as MathLinks;
+    mathlinks.update(file);
 }
 
 /**

--- a/src/api/provider.ts
+++ b/src/api/provider.ts
@@ -1,7 +1,6 @@
 import { MathLinksAPIAccount } from './deprecated';
 import { BlockSubpathResult, Component, HeadingSubpathResult, TFile } from 'obsidian';
 import { getMathLinkFromSubpath, getMathLinkFromTemplates } from '../links/helper';
-import { update } from './index';
 import MathLinks from '../main';
 
 /**
@@ -20,7 +19,7 @@ export abstract class Provider extends Component {
 
     set enableInSourceMode(enable: boolean) {
         this._enableInSourceMode = enable;
-        update(this.mathLinks.app);
+        this.mathLinks.update();
     }
 
     public abstract provide(
@@ -34,7 +33,7 @@ export abstract class Provider extends Component {
         const providers = this.mathLinks.providers;
         let index = providers.findIndex(({ provider }) => provider === this);
         providers.splice(index, 1);
-        update(this.mathLinks.app);
+        this.mathLinks.update();
     }
 }
 
@@ -45,7 +44,7 @@ export class NativeProvider extends Provider {
 
     set enableInSourceMode(enable: boolean) {
         this.mathLinks.settings.enableInSourceMode = enable;
-        update(this.mathLinks.app);
+        this.mathLinks.update();
         this.mathLinks.saveSettings();
     }
 

--- a/src/links/preview.ts
+++ b/src/links/preview.ts
@@ -28,7 +28,7 @@
  */
 
 import { Keymap, editorInfoField, editorLivePreviewField, getLinkpath } from "obsidian";
-import { Transaction, EditorState, RangeSet, RangeSetBuilder, RangeValue, StateEffect, StateEffectType, StateField, EditorSelection, Extension } from "@codemirror/state";
+import { Transaction, EditorState, RangeSet, RangeSetBuilder, RangeValue, StateEffectType, StateField, EditorSelection, Extension } from "@codemirror/state";
 import {
     Decoration,
     DecorationSet,
@@ -56,8 +56,6 @@ function selectionAndRangeOverlap(selection: EditorSelection, rangeFrom: number,
 function hasEffect<T>(tr: Transaction, effectType: StateEffectType<T>): boolean {
     return tr.effects.some(effect => effect.is(effectType));
 }
-
-export const forceUpdateEffect = StateEffect.define<null>();
 
 class MathLinkInfo extends RangeValue {
     constructor(public linkText: string, public mathLink: string) {
@@ -173,7 +171,7 @@ export const createEditorExtensions = (plugin: MathLinks): Extension[] => {
     const mathLinkInfoField = StateField.define<RangeSet<MathLinkInfo>>({
         create: buildField,
         update(oldFields, tr) {
-            return tr.docChanged || hasEffect(tr, forceUpdateEffect) ? buildField(tr.state) : oldFields;
+            return tr.docChanged || hasEffect(tr, plugin.forceUpdateEffect) ? buildField(tr.state) : oldFields;
         }
     });
 
@@ -272,7 +270,7 @@ export const createEditorExtensions = (plugin: MathLinks): Extension[] => {
                     this.decorations = Decoration.none;
                 }
 
-                if (update.transactions.some(tr => hasEffect(tr, forceUpdateEffect))) {
+                if (update.transactions.some(tr => hasEffect(tr, plugin.forceUpdateEffect))) {
                     this.decorations = this.buildDecorations(update.view);
                 } else if (update.docChanged) {
                     this.decorations = this.decorations.map(update.changes);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,5 @@
-import { App, MarkdownView, TAbstractFile, TFile, TFolder, WorkspaceLeaf } from "obsidian";
+import { TAbstractFile, TFolder } from "obsidian";
 import MathLinks from "./main";
-import { forceUpdateEffect } from "./links/preview";
 
 // Check if path is excluded
 export function isExcluded(plugin: MathLinks, file: TAbstractFile): boolean {
@@ -40,19 +39,4 @@ export function isEqualToOrChildOf(file1: TAbstractFile, file2: TAbstractFile): 
             ancestor = ancestor.parent;
         }
     }
-}
-
-// eventName: see src/type.d.ts
-export function informChange(app: App, eventName: string, ...callbackArgs: [file?: TFile]) {
-    // trigger an event informing this update
-    app.metadataCache.trigger(eventName, ...callbackArgs);
-
-    // refresh mathLinks display based on the new metadata
-    app.workspace.iterateRootLeaves((leaf: WorkspaceLeaf) => {
-        if (leaf.view instanceof MarkdownView && leaf.view.getMode() == 'source') {
-            leaf.view.editor.cm?.dispatch({
-                effects: forceUpdateEffect.of(null)
-            });
-        }
-    });
 }


### PR DESCRIPTION
1. When called with `file: TFile`, the `update()` function now dispatches a transaction only for a markdown view whose file links to the specified TFile.

2. It turned out that the previous implementation made it impossible for the `update()` API function call to dispatch `forceUpdateEffect` properly. This was because `forceUpdateEffect` was defined like this:

https://github.com/zhaoshenzhai/obsidian-mathlinks/blob/8869a1df04cdcd28c1c9376b7d156187d6a45b31/src/links/preview.ts#L60

This is not problematic at all for MathLinks itself, but for another plugin using the API, this creates a different `forceUpdateEffect` in its `main.js` as a result of bundling. As a result, this plugin dispatches `forceUpdateEffect` that is different from the original one, and this new state effect has no effect on the decorations MathLinks creates.

I fixed this by making `forceUpdateEffect` a member property of the MathLinks plugin instance. This way, we can always reference to the same `forceUpdateEffect` instance.

https://github.com/zhaoshenzhai/obsidian-mathlinks/blob/cc7ef76939563ea1f9dfcb20ce32589045a99d62/src/main.ts#L17