### PR TITLE
API fix

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -7,15 +7,25 @@ import { Provider } from "./provider";
 import MathLinks from "../main";
 
 
+/** 
+ * Create a provider instance using the given factory function and register it with MathLinks.
+ * You have accesss to the MathLinks plugin instance inside the factory function. 
+ * @returns The created provider instance.
+ */
 export function addProvider<CustomProvider extends Provider>(app: App, providerFactory: (mathLinks: MathLinks) => CustomProvider): CustomProvider {
     if (!isPluginEnabled(app)) throw Error("MathLinks API: MathLinks is not enabled.");
-    const mathLinks = app.plugins.plugins.mathlinks as MathLinks;
+    const mathLinks = app.plugins.plugins.mathlinks as MathLinks | undefined;
+    if (!mathLinks) throw Error("MathLinks API: MathLinks has not been loaded yet.");
     const provider = providerFactory(mathLinks);
     mathLinks.registerProvider(provider);
     return provider;
 }
 
-export function isPluginEnabled(app: App) {
+/**
+ * Check if MathLinks is enabled. Even if it returns true, it doesn't mean 
+ * MathLinks has already been loaded at the moment.
+ */
+export function isPluginEnabled(app: App): boolean {
     return app.plugins.enabledPlugins.has("mathlinks");
 }
 
@@ -26,8 +36,9 @@ export function isPluginEnabled(app: App) {
  */
 export function update(app: App, file?: TFile) {
     if (!isPluginEnabled(app)) throw Error("MathLinks API: MathLinks is not enabled.");
-    const mathlinks = app.plugins.plugins.mathlinks as MathLinks;
-    mathlinks.update(file);
+    const mathLinks = app.plugins.plugins.mathlinks as MathLinks | undefined;
+    if (!mathLinks) throw Error("MathLinks API: MathLinks has not been loaded yet.");
+    mathLinks.update(file);
 }
 
 /**


### PR DESCRIPTION
API functions now throw an error properly when MathLinks is in the list of enabled plugins but not fully loaded yet.

## Details

The `isPluginEnabled` function seems to just check whether the given plugin id is in the list of "enabled plugins" (i.e. the array in `community-plugins.json`). This means it is possible that this function returns `true` but MathLinks has not been loaded at the moment of the function call.

https://github.com/zhaoshenzhai/obsidian-mathlinks/blob/5cd0836b973bfe090df3476ed937684adacceb9a/src/api/index.ts#L18-L20

As a result, `app.plugins.plugins.mathlinks` can be `undefined` even when `isPluginEnabled()` returns `true`. So the following `as MathLinks` turned out to be wrong. This PR fixes it.

https://github.com/zhaoshenzhai/obsidian-mathlinks/blob/5cd0836b973bfe090df3476ed937684adacceb9a/src/api/index.ts#L11-L12