### PR TITLE
Fix an error happenning when this.app.metadataCache.resolvedLinks[leaf.view.file.path] is undefined

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -122,7 +122,7 @@ export default class MathLinks extends Plugin {
                 let shouldDispatch = !file;
                 // Should dispatch if Obsidian is still yet to resolve links
                 shouldDispatch ||= !this.app.metadataCache.resolvedLinks;
-                if (file && leaf.view.file && this.app.metadataCache.resolvedLinks) {
+                if (file && leaf.view.file && this.app.metadataCache.resolvedLinks[leaf.view.file.path]) {
                     // Should dispatch if the opened file (leaf.view.file) links to the changed file (file)
                     shouldDispatch ||= file.path in this.app.metadataCache.resolvedLinks[leaf.view.file.path];
                 }


### PR DESCRIPTION
I thought it's been fixed in #63, but I noticed that I misunderstood the problem: `this.app.metadataCache.resolvedLinks` was certainly defined, but `this.app.metadataCache.resolvedLinks[leaf.view.file.path]` was undefined (i.e. non-existing key).

